### PR TITLE
US672844: Changes related to naming convenstion and metadata

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/BundleFileBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/BundleFileBuilder.java
@@ -33,8 +33,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.BUNDLE_EXTENSION;
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.DELETE_BUNDLE_EXTENSION;
+import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.*;
 
 @Singleton
 public class BundleFileBuilder {
@@ -63,8 +62,7 @@ public class BundleFileBuilder {
         this.cache = cache;
     }
 
-    public void buildBundle(File rootDir, File outputDir, List<File> dependencies, String projectName,
-                            String projectGroupName, String projectVersion) {
+    public void buildBundle(File rootDir, File outputDir, List<File> dependencies, ProjectInfo projectInfo) {
         final DocumentBuilder documentBuilder = documentTools.getDocumentBuilder();
         final Document document = documentBuilder.newDocument();
 
@@ -119,16 +117,16 @@ public class BundleFileBuilder {
 
         //Zip
         final Map<String, BundleArtifacts> bundleElementMap = bundleEntityBuilder.build(bundle,
-                EntityBuilder.BundleType.DEPLOYMENT, document, projectName, projectGroupName, projectVersion);
+                EntityBuilder.BundleType.DEPLOYMENT, document, projectInfo);
         bundleElementMap.forEach((k, v) -> writeBundleArtifacts(k, v, outputDir));
     }
 
-    private void writeBundleArtifacts(final String key, final BundleArtifacts bundleArtifacts, File outputDir) {
+    private void writeBundleArtifacts(final String bundleName, final BundleArtifacts bundleArtifacts, File outputDir) {
         documentFileUtils.createFile(bundleArtifacts.getBundle(), new File(outputDir,
-                key + BUNDLE_EXTENSION).toPath());
+                bundleArtifacts.getBundleFileName()).toPath());
         documentFileUtils.createFile(bundleArtifacts.getDeleteBundle(), new File(outputDir,
-                key + DELETE_BUNDLE_EXTENSION).toPath());
-        jsonFileUtils.createBundleMetadataFile(bundleArtifacts.getBundleMetadata(), key, outputDir);
+                bundleArtifacts.getDeleteBundleFileName()).toPath());
+        jsonFileUtils.createBundleMetadataFile(bundleArtifacts.getBundleMetadata(), bundleName, outputDir);
     }
 
     protected <E extends GatewayEntity> void logOverriddenEntities(Bundle bundle, Set<Bundle> dependencyBundles, Class<E> entityClass) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/ProjectInfo.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/ProjectInfo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 CA. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+package com.ca.apim.gateway.cagatewayconfig;
+
+public class ProjectInfo {
+    private final String name;
+    private final String groupName;
+    private final String version;
+
+    public ProjectInfo(String name, String groupName, String version) {
+        this.name = name;
+        this.groupName = groupName;
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -13,7 +13,6 @@ import com.ca.apim.gateway.cagatewayconfig.config.spec.EnvironmentType;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
-import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -200,7 +199,6 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     }
 
     public String getType() {
-        return "encass";
+        return EntityTypes.ENCAPSULATED_ASSERTION_TYPE;
     }
-
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -198,7 +198,13 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
         this.annotatedEntity = annotatedEntity;
     }
 
+    @Override
     public String getType() {
         return EntityTypes.ENCAPSULATED_ASSERTION_TYPE;
+    }
+
+    @Override
+    public String getShortenedType() {
+        return "encass";
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GatewayEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GatewayEntity.java
@@ -6,7 +6,6 @@
 
 package com.ca.apim.gateway.cagatewayconfig.beans;
 
-import com.ca.apim.gateway.cagatewayconfig.bundle.builder.AnnotatedEntity;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.Metadata;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
@@ -246,6 +246,11 @@ public class Policy extends Folderable implements AnnotableEntity {
     }
 
     public String getType(){
+        return EntityTypes.POLICY_TYPE;
+    }
+
+    @Override
+    public String getShortenedType() {
         return "policy";
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Service.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Service.java
@@ -12,6 +12,7 @@ import com.ca.apim.gateway.cagatewayconfig.bundle.builder.AnnotationDeserializer
 import com.ca.apim.gateway.cagatewayconfig.config.spec.BundleGeneration;
 import com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile;
 import com.ca.apim.gateway.cagatewayconfig.config.spec.EnvironmentType;
+import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -177,8 +178,13 @@ public class Service extends Folderable implements AnnotableEntity {
         return annotatedEntity;
     }
 
+    @Override
     public String getType(){
-        return "service";
+        return EntityTypes.SERVICE_TYPE;
     }
 
+    @Override
+    public String getShortenedType() {
+        return "service";
+    }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotableEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotableEntity.java
@@ -30,6 +30,14 @@ public interface AnnotableEntity {
     String getType();
 
     /**
+     * Returns short name of Entity Type. For example, for ENCAPSUPATED_ASSERTION it returns "encass", for POLICY
+     * it returns "policy", and for SERVICE it returns "service"
+     *
+     * @return Shortened type
+     */
+    String getShortenedType();
+
+    /**
 
      * This method returns all the Annotation applied to the entity.
      *

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotableEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotableEntity.java
@@ -58,6 +58,7 @@ public interface AnnotableEntity {
             AnnotatedEntity<GatewayEntity> annotatedEntity = new AnnotatedEntity(this);
             annotations.forEach(annotation -> {
                 if (ANNOTATION_TYPE_BUNDLE.equalsIgnoreCase(annotation.getType())) {
+                    annotatedEntity.setMetadataId(annotation.getId());
                     annotatedEntity.setTags(annotation.getTags());
                     annotatedEntity.setEntityType(EntityTypes.ENCAPSULATED_ASSERTION_TYPE);
                     annotatedEntity.setBundleName(annotation.getName());

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedBundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedBundle.java
@@ -44,7 +44,7 @@ public class AnnotatedBundle extends Bundle {
 
     public String getUniquePrefix() {
         AnnotableEntity annotableEntity = (AnnotableEntity) annotatedEntity.getEntity();
-        return projectInfo.getName() + "-" + annotableEntity.getType() + "-" + PathUtils.extractName(annotatedEntity.getEntityName()) + "-";
+        return projectInfo.getName() + "-" + annotableEntity.getShortenedType() + "-" + PathUtils.extractName(annotatedEntity.getEntityName()) + "-";
     }
 
     public String getUniqueSuffix() {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedBundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedBundle.java
@@ -1,5 +1,6 @@
 package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.GatewayEntity;
 import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
@@ -8,12 +9,13 @@ import org.apache.commons.lang3.StringUtils;
 public class AnnotatedBundle extends Bundle {
     private Bundle fullBundle;
     private AnnotatedEntity<? extends GatewayEntity> annotatedEntity;
-    private String projectName;
-    private String projectVersion;
+    private ProjectInfo projectInfo;
 
-    public AnnotatedBundle(Bundle fullBundle, AnnotatedEntity<? extends GatewayEntity> annotatedEntity) {
+    public AnnotatedBundle(Bundle fullBundle, AnnotatedEntity<? extends GatewayEntity> annotatedEntity,
+                           ProjectInfo projectInfo) {
         this.fullBundle = fullBundle;
         this.annotatedEntity = annotatedEntity;
+        this.projectInfo = projectInfo;
     }
 
     public AnnotatedEntity<? extends GatewayEntity> getAnnotatedEntity() {
@@ -32,37 +34,21 @@ public class AnnotatedBundle extends Bundle {
         this.fullBundle = fullBundle;
     }
 
-    public String getProjectName() {
-        return projectName;
-    }
-
-    public void setProjectName(String projectName) {
-        this.projectName = projectName;
-    }
-
-    public String getProjectVersion() {
-        return projectVersion;
-    }
-
-    public void setProjectVersion(String projectVersion) {
-        this.projectVersion = projectVersion;
-    }
-
     public String getBundleName() {
         if (StringUtils.isBlank(annotatedEntity.getBundleName())) {
-            return projectName + "-" + annotatedEntity.getEntityName() + "-" + projectVersion;
+            return projectInfo.getName() + "-" + annotatedEntity.getEntityName() + "-" + projectInfo.getVersion();
         } else {
-            return annotatedEntity.getBundleName() + "-" + projectVersion;
+            return annotatedEntity.getBundleName() + "-" + projectInfo.getVersion();
         }
     }
 
     public String getUniquePrefix() {
         AnnotableEntity annotableEntity = (AnnotableEntity) annotatedEntity.getEntity();
-        return projectName + "-" + annotableEntity.getType() + "-" + PathUtils.extractName(annotatedEntity.getEntityName()) + "-";
+        return projectInfo.getName() + "-" + annotableEntity.getType() + "-" + PathUtils.extractName(annotatedEntity.getEntityName()) + "-";
     }
 
     public String getUniqueSuffix() {
-        return "-" + projectVersion;
+        return "-" + projectInfo.getVersion();
     }
 
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedEntity.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 
 public class AnnotatedEntity<T> {
     private final T entity;
+    private String metadataId;
     private String entityName;
     private String entityType;
     private String bundleName;
@@ -19,6 +20,13 @@ public class AnnotatedEntity<T> {
     private String id;
     private String guid;
 
+    public String getMetadataId() {
+        return metadataId;
+    }
+
+    public void setMetadataId(String metadataId) {
+        this.metadataId = metadataId;
+    }
 
     public String getId() {
         return id;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleArtifacts.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleArtifacts.java
@@ -13,11 +13,16 @@ public class BundleArtifacts {
     private final Element bundle;
     private final Element deleteBundle;
     private final BundleMetadata bundleMetadata;
+    private final String bundleFileName;
+    private final String deleteBundleFileName;
 
-    public BundleArtifacts(Element bundle, Element deleteBundle, BundleMetadata bundleMetadata) {
+    public BundleArtifacts(Element bundle, Element deleteBundle, BundleMetadata bundleMetadata, String bundleFileName
+            , String deleteBundleFileName) {
         this.bundle = bundle;
         this.deleteBundle = deleteBundle;
         this.bundleMetadata = bundleMetadata;
+        this.bundleFileName = bundleFileName;
+        this.deleteBundleFileName = deleteBundleFileName;
     }
 
     public Element getBundle() {
@@ -30,5 +35,13 @@ public class BundleArtifacts {
 
     public BundleMetadata getBundleMetadata() {
         return bundleMetadata;
+    }
+
+    public String getBundleFileName() {
+        return bundleFileName;
+    }
+
+    public String getDeleteBundleFileName() {
+        return deleteBundleFileName;
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -56,8 +56,8 @@ public class BundleEntityBuilder {
             final Element fullBundle = bundleDocumentBuilder.build(document, entities);
             final String bundleName = StringUtils.isBlank(projectInfo.getVersion()) ? projectInfo.getName() :
                     projectInfo.getName() + "-" + projectInfo.getVersion();
-            final String bundleFileName = generateBundleFileName(bundleType, true, false, bundleName);
-            final String deleteBundleFileName = generateBundleFileName(bundleType, true, true, bundleName);
+            final String bundleFileName = generateBundleFileName(bundleType, false, bundleName);
+            final String deleteBundleFileName = generateBundleFileName(bundleType, true, bundleName);
             artifacts.put(bundleName, new BundleArtifacts(fullBundle, null, null, bundleFileName,
                     deleteBundleFileName));
         }
@@ -93,9 +93,9 @@ public class BundleEntityBuilder {
                                 final BundleMetadata bundleMetadata = bundleMetadataBuilder.build(annotatedBundle,
                                         annotatedEntity, entities, projectInfo);
 
-                                final String bundleFileName = generateBundleFileName(bundleType, false, false,
+                                final String bundleFileName = generateBundleFileName(bundleType, false,
                                         annotatedBundle.getBundleName());
-                                final String deleteBundleFileName = generateBundleFileName(bundleType, false, true,
+                                final String deleteBundleFileName = generateBundleFileName(bundleType, true,
                                         annotatedBundle.getBundleName());
                                 annotatedElements.put(annotatedBundle.getBundleName(),
                                         new BundleArtifacts(bundleElement, deleteBundleElement, bundleMetadata,
@@ -325,17 +325,12 @@ public class BundleEntityBuilder {
         return null;
     }
 
-    private String generateBundleFileName(BundleType bundleType, boolean isFullBundle,
-                                          boolean isDeleteBundle, String bundleName) {
+    private String generateBundleFileName(BundleType bundleType, boolean isDeleteBundle, String bundleName) {
         if (bundleType == BundleType.ENVIRONMENT) {
             return bundleName;
         }
         String filenameSuffix = isDeleteBundle ? DELETE_BUNDLE_EXTENSION : INSTALL_BUNDLE_EXTENSION;
-        if (isFullBundle) {
-            return bundleName + "-full" + filenameSuffix;
-        } else {
-            return bundleName + "-policy" + filenameSuffix;
-        }
+        return bundleName + "-policy" + filenameSuffix;
     }
 
     @VisibleForTesting

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -390,6 +390,13 @@ public class BundleEntityBuilder {
         return null;
     }
 
+    /**
+     * Generates the filename for the install bundle and delete bundle files/
+     *
+     * @param isDeleteBundle is delete bundle
+     * @param bundleName compiled prefix for filename from project details or from annotations
+     * @return filename for the bundle
+     */
     private String generateBundleFileName(boolean isDeleteBundle, String bundleName) {
         String filenameSuffix = isDeleteBundle ? DELETE_BUNDLE_EXTENSION : INSTALL_BUNDLE_EXTENSION;
         return bundleName + "-policy" + filenameSuffix;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -327,10 +327,10 @@ public class BundleEntityBuilder {
 
     private String generateBundleFileName(BundleType bundleType, boolean isFullBundle,
                                           boolean isDeleteBundle, String bundleName) {
-        String filenameSuffix = isDeleteBundle ? DELETE_BUNDLE_EXTENSION : INSTALL_BUNDLE_EXTENSION;
         if (bundleType == BundleType.ENVIRONMENT) {
-            return bundleName + filenameSuffix;
+            return bundleName;
         }
+        String filenameSuffix = isDeleteBundle ? DELETE_BUNDLE_EXTENSION : INSTALL_BUNDLE_EXTENSION;
         if (isFullBundle) {
             return bundleName + "-full" + filenameSuffix;
         } else {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadata.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadata.java
@@ -12,16 +12,17 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.List;
 
-@JsonPropertyOrder({"id", "name", "groupName", "version", "type", "tags", "description", "reusable", "redeployable",
-        "hasRouting", "environmentIncluded", "definedEntities", "environmentEntities", "dependencies"})
+@JsonPropertyOrder({"metaVersion", "id", "name", "groupName", "version", "type", "tags", "description", "reusable",
+        "redeployable", "hasRouting", "environmentIncluded", "definedEntities", "environmentEntities", "dependencies"})
 public class BundleMetadata implements Metadata {
-    private String type;
-    private String name;
-    private String id;
-    private String version;
-    private String groupName;
+    @SuppressWarnings({"unused", "java:S1170"}) // Suppress IntelliJ warnings for this field
+    private final String metaVersion = "1.0";
+    private final String type;
+    private final String name;
+    private final String id;
+    private final String version;
+    private final String groupName;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private String description;
     private Collection<Metadata> definedEntities;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadata.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadata.java
@@ -42,6 +42,10 @@ public class BundleMetadata implements Metadata {
         this.version = version;
     }
 
+    public String getMetaVersion() {
+        return metaVersion;
+    }
+
     @Override
     public String getType() {
         return type;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
@@ -8,6 +8,7 @@ package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
 import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.Encass;
+import com.ca.apim.gateway.cagatewayconfig.beans.GatewayEntity;
 import com.ca.apim.gateway.cagatewayconfig.beans.Policy;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import org.apache.commons.lang3.StringUtils;
@@ -43,7 +44,7 @@ public class BundleMetadataBuilder {
     public BundleMetadata build(final AnnotatedBundle annotatedBundle, final List<Entity> dependentEntities,
                                 ProjectInfo projectInfo) {
         if (annotatedBundle != null && annotatedBundle.getAnnotatedEntity() != null) {
-            AnnotatedEntity annotatedEntity = annotatedBundle.getAnnotatedEntity();
+            AnnotatedEntity<? extends GatewayEntity> annotatedEntity = annotatedBundle.getAnnotatedEntity();
             final Encass encass = (Encass) annotatedEntity.getEntity();
             final String bundleName = annotatedBundle.getBundleName();
             final String name = bundleName.substring(0, bundleName.indexOf(projectInfo.getVersion()) - 1);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
@@ -6,6 +6,7 @@
 
 package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.Encass;
 import com.ca.apim.gateway.cagatewayconfig.beans.GatewayEntity;
 import com.ca.apim.gateway.cagatewayconfig.beans.Policy;
@@ -21,14 +22,13 @@ public class BundleMetadataBuilder {
 
     public BundleMetadata build(final AnnotatedBundle annotatedBundle,
                                 final AnnotatedEntity<? extends GatewayEntity> annotatedEntity,
-                                final List<Entity> dependentEntities, final String projectGroupName,
-                                final String projectVersion) {
+                                final List<Entity> dependentEntities, ProjectInfo projectInfo) {
         final Encass encass = (Encass) annotatedEntity.getEntity();
         final String bundleName = annotatedBundle.getBundleName();
-        final String name = bundleName.substring(0, bundleName.indexOf(projectVersion) - 1);
+        final String name = bundleName.substring(0, bundleName.indexOf(projectInfo.getVersion()) - 1);
 
         BundleMetadata.Builder builder = new BundleMetadata.Builder(encass.getType(), encass.getGuid(), name,
-                projectGroupName, projectVersion);
+                projectInfo.getGroupName(), projectInfo.getVersion());
         builder.description(annotatedEntity.getDescription());
         builder.environmentEntities(getEnvironmentDependenciesMetadata(dependentEntities));
         builder.tags(annotatedEntity.getTags());

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/Metadata.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/Metadata.java
@@ -6,10 +6,8 @@
 
 package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonPropertyOrder({"type", "name", "id", "guid"})
 public interface Metadata {
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/PolicyLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/PolicyLoader.java
@@ -46,8 +46,10 @@ public class PolicyLoader implements BundleEntityLoader {
         final String policyType = getSingleChildElementTextContent(policyDetails, POLICY_TYPE);
         final Map<String, Object> policyDetailProperties = mapPropertiesElements(getSingleChildElement(policyDetails, PROPERTIES, true), PROPERTIES);
         final String policyTag = (String) policyDetailProperties.get(PROPERTY_TAG);
-        final boolean hasRouting =
-                BooleanUtils.toBooleanDefaultIfNull((Boolean) policyDetailProperties.get(PROPERTY_HAS_ROUTING), false);
+        boolean hasRouting = false;
+        if (policyDetailProperties.get(PROPERTY_HAS_ROUTING) != null) {
+            hasRouting = BooleanUtils.toBoolean(policyDetailProperties.get(PROPERTY_HAS_ROUTING).toString());
+        }
         if (!PolicyType.isValidType(policyType, policyTag)) {
             LOGGER.log(Level.WARNING, () -> {
                 if (policyTag != null) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
@@ -6,6 +6,7 @@
 
 package com.ca.apim.gateway.cagatewayconfig.environment;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleArtifacts;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleEntityBuilder;
@@ -30,6 +31,7 @@ import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.DE
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static java.util.stream.Collectors.toList;
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.PLUGIN;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @Singleton
 public class EnvironmentBundleCreator {
@@ -70,11 +72,12 @@ public class EnvironmentBundleCreator {
         final DocumentBuilder documentBuilder = documentTools.getDocumentBuilder();
         final Document document = documentBuilder.newDocument();
 
+        // Passing Bundle name and version string with config env name (<name>-<version>-*env) as project name
         Map<String, BundleArtifacts> bundleElements = bundleEntityBuilder.build(environmentBundle,
-                EntityBuilder.BundleType.ENVIRONMENT, document, bundleFileName, "", null);
+                EntityBuilder.BundleType.ENVIRONMENT, document, new ProjectInfo(bundleFileName, EMPTY, EMPTY));
         for (Map.Entry<String, BundleArtifacts> entry : bundleElements.entrySet()) {
             documentFileUtils.createFile(entry.getValue().getBundle(), new File(bundleFolderPath,
-                    entry.getKey()).toPath());
+                    entry.getValue().getBundleFileName()).toPath());
         }
         return environmentBundle;
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
@@ -75,9 +75,9 @@ public class EnvironmentBundleCreator {
         // Passing Bundle name and version string with config env name (<name>-<version>-*env) as project name
         Map<String, BundleArtifacts> bundleElements = bundleEntityBuilder.build(environmentBundle,
                 EntityBuilder.BundleType.ENVIRONMENT, document, new ProjectInfo(bundleFileName, EMPTY, EMPTY));
-        for (Map.Entry<String, BundleArtifacts> entry : bundleElements.entrySet()) {
-            documentFileUtils.createFile(entry.getValue().getBundle(), new File(bundleFolderPath,
-                    entry.getValue().getBundleFileName()).toPath());
+        for (BundleArtifacts bundleArtifacts : bundleElements.values()) {
+            documentFileUtils.createFile(bundleArtifacts.getBundle(), new File(bundleFolderPath,
+                    bundleArtifacts.getBundleFileName()).toPath());
         }
         return environmentBundle;
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
@@ -55,7 +55,7 @@ public class EnvironmentBundleCreator {
                                           String templatizedBundleFolderPath,
                                           String environmentConfigurationFolderPath,
                                           EnvironmentBundleCreationMode mode,
-                                          String bundleFileName,
+                                          String envInstallBundleFilename,
                                           String policyBundleName) {
         Bundle environmentBundle = new Bundle();
         environmentBundleBuilder.build(environmentBundle, environmentProperties, environmentConfigurationFolderPath, mode);
@@ -71,12 +71,14 @@ public class EnvironmentBundleCreator {
         final DocumentBuilder documentBuilder = documentTools.getDocumentBuilder();
         final Document document = documentBuilder.newDocument();
 
-        // Passing Bundle name and version string with config env name (<name>-<version>-*env) as project name
+        // Passing Bundle name and version string with config env name (<name>-<version>-*env.install.bundle) as project name
         Map<String, BundleArtifacts> bundleElements = bundleEntityBuilder.build(environmentBundle,
-                EntityBuilder.BundleType.ENVIRONMENT, document, new ProjectInfo(bundleFileName, EMPTY, EMPTY));
+                EntityBuilder.BundleType.ENVIRONMENT, document, new ProjectInfo(envInstallBundleFilename, EMPTY, EMPTY));
         for (BundleArtifacts bundleArtifacts : bundleElements.values()) {
             documentFileUtils.createFile(bundleArtifacts.getBundle(), new File(bundleFolderPath,
                     bundleArtifacts.getBundleFileName()).toPath());
+            documentFileUtils.createFile(bundleArtifacts.getDeleteBundle(), new File(bundleFolderPath,
+                    bundleArtifacts.getDeleteBundleFileName()).toPath());
         }
         return environmentBundle;
     }
@@ -84,7 +86,7 @@ public class EnvironmentBundleCreator {
     private List<TemplatizedBundle> collectTemplatizedBundleFiles(String templatizedBundleFolderPath,
                                                                   EnvironmentBundleCreationMode mode,
                                                                   String policyBundleName, String bundleFolderPath) {
-        final String extension = mode != PLUGIN ? BUNDLE_EXTENSION : policyBundleName + BUNDLE_EXTENSION;
+        final String extension = mode != PLUGIN ? ".bundle" : policyBundleName + INSTALL_BUNDLE_EXTENSION;
         return collectFiles(templatizedBundleFolderPath, extension).stream()
                 .filter(file -> !StringUtils.endsWithIgnoreCase(file.getName(), DELETE_BUNDLE_EXTENSION))
                 .map(f -> new FileTemplatizedBundle(f, new File(bundleFolderPath, f.getName())))

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
@@ -86,7 +86,7 @@ public class EnvironmentBundleCreator {
     private List<TemplatizedBundle> collectTemplatizedBundleFiles(String templatizedBundleFolderPath,
                                                                   EnvironmentBundleCreationMode mode,
                                                                   String policyBundleName, String bundleFolderPath) {
-        final String extension = mode != PLUGIN ? ".bundle" : policyBundleName + INSTALL_BUNDLE_EXTENSION;
+        final String extension = mode != PLUGIN ? BUNDLE_EXTENSION : policyBundleName + INSTALL_BUNDLE_EXTENSION;
         return collectFiles(templatizedBundleFolderPath, extension).stream()
                 .filter(file -> !StringUtils.endsWithIgnoreCase(file.getName(), DELETE_BUNDLE_EXTENSION))
                 .map(f -> new FileTemplatizedBundle(f, new File(bundleFolderPath, f.getName())))

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleUtils.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.BUNDLE_EXTENSION;
+import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElementTextContent;
@@ -50,7 +50,7 @@ public class EnvironmentBundleUtils {
             return cache.getBundle(templatizedBundlesFolderPath);
         } else {
             EntityBundleLoader loader = InjectionRegistry.getInjector().getInstance(EntityBundleLoader.class);
-            List<File> deploymentBundleFiles = collectFiles(templatizedBundlesFolderPath, BUNDLE_EXTENSION);
+            List<File> deploymentBundleFiles = collectFiles(templatizedBundlesFolderPath, INSTALL_BUNDLE_EXTENSION);
             cache.putBundle(templatizedBundlesFolderPath, loader.load(deploymentBundleFiles, BundleLoadingOperation.EXPORT));
             return loader.load(deploymentBundleFiles, BundleLoadingOperation.EXPORT);
         }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
@@ -6,6 +6,7 @@
 
 package com.ca.apim.gateway.cagatewayconfig.environment;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.*;
 import com.ca.apim.gateway.cagatewayconfig.environment.TemplatizedBundle.StringTemplatizedBundle;
@@ -14,6 +15,7 @@ import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtilsException;
 import com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
+import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -106,7 +108,7 @@ public class FullBundleCreator {
         final DocumentBuilder documentBuilder = documentTools.getDocumentBuilder();
         final Document document = documentBuilder.newDocument();
         Map<String, BundleArtifacts> bundleElements = bundleEntityBuilder.build(environmentBundle,
-                EntityBuilder.BundleType.ENVIRONMENT, document, bundleFileName, "", "");
+                EntityBuilder.BundleType.ENVIRONMENT, document, new ProjectInfo(bundleFileName, EMPTY, EMPTY));
         Element bundleElement = null;
         for(Map.Entry<String, BundleArtifacts> entry: bundleElements.entrySet()) {
             // generate the environment bundle

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
@@ -18,7 +18,6 @@ import com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/file/DocumentFileUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/file/DocumentFileUtils.java
@@ -6,12 +6,9 @@
 
 package com.ca.apim.gateway.cagatewayconfig.util.file;
 
-import com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
-import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -26,9 +23,6 @@ public class DocumentFileUtils {
     public static final String BUNDLE_EXTENSION = ".bundle";
     public static final String DELETE_BUNDLE_EXTENSION = ".delete" + BUNDLE_EXTENSION;
     public static final String INSTALL_BUNDLE_EXTENSION = ".install" + BUNDLE_EXTENSION;
-
-    public static final String POLICY_INSTALL_BUNDLE_EXTENSION = "-policy" + INSTALL_BUNDLE_EXTENSION;
-    public static final String POLICY_DELETE_BUNDLE_EXTENSION = "-policy" + DELETE_BUNDLE_EXTENSION;
 
     private DocumentFileUtils(DocumentTools documentTools) {
         this.documentTools = documentTools;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/file/DocumentFileUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/file/DocumentFileUtils.java
@@ -23,6 +23,7 @@ public class DocumentFileUtils {
     public static final String BUNDLE_EXTENSION = ".bundle";
     public static final String DELETE_BUNDLE_EXTENSION = ".delete.bundle";
     public static final String INSTALL_BUNDLE_EXTENSION = ".install.bundle";
+    public static final String ENV_INSTALL_BUNDLE_NAME_SUFFIX = "env" + INSTALL_BUNDLE_EXTENSION;
     public static final String FULL_INSTALL_BUNDLE_NAME_SUFFIX = "-full" + INSTALL_BUNDLE_EXTENSION;
 
     private DocumentFileUtils(DocumentTools documentTools) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/file/DocumentFileUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/file/DocumentFileUtils.java
@@ -21,9 +21,8 @@ public class DocumentFileUtils {
     public static final DocumentFileUtils INSTANCE = new DocumentFileUtils(DocumentTools.INSTANCE);
     private final DocumentTools documentTools;
     public static final String BUNDLE_EXTENSION = ".bundle";
-    public static final String DELETE_BUNDLE_EXTENSION = ".delete" + BUNDLE_EXTENSION;
-    public static final String INSTALL_BUNDLE_EXTENSION = ".install" + BUNDLE_EXTENSION;
-    public static final String ENV_INSTALL_BUNDLE_NAME_SUFFIX = "env" + INSTALL_BUNDLE_EXTENSION;
+    public static final String DELETE_BUNDLE_EXTENSION = ".delete.bundle";
+    public static final String INSTALL_BUNDLE_EXTENSION = ".install.bundle";
     public static final String FULL_INSTALL_BUNDLE_NAME_SUFFIX = "-full" + INSTALL_BUNDLE_EXTENSION;
 
     private DocumentFileUtils(DocumentTools documentTools) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/file/DocumentFileUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/file/DocumentFileUtils.java
@@ -6,9 +6,12 @@
 
 package com.ca.apim.gateway.cagatewayconfig.util.file;
 
+import com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
+import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -22,6 +25,10 @@ public class DocumentFileUtils {
     private final DocumentTools documentTools;
     public static final String BUNDLE_EXTENSION = ".bundle";
     public static final String DELETE_BUNDLE_EXTENSION = ".delete" + BUNDLE_EXTENSION;
+    public static final String INSTALL_BUNDLE_EXTENSION = ".install" + BUNDLE_EXTENSION;
+
+    public static final String POLICY_INSTALL_BUNDLE_EXTENSION = "-policy" + INSTALL_BUNDLE_EXTENSION;
+    public static final String POLICY_DELETE_BUNDLE_EXTENSION = "-policy" + DELETE_BUNDLE_EXTENSION;
 
     private DocumentFileUtils(DocumentTools documentTools) {
         this.documentTools = documentTools;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/file/DocumentFileUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/file/DocumentFileUtils.java
@@ -23,6 +23,8 @@ public class DocumentFileUtils {
     public static final String BUNDLE_EXTENSION = ".bundle";
     public static final String DELETE_BUNDLE_EXTENSION = ".delete" + BUNDLE_EXTENSION;
     public static final String INSTALL_BUNDLE_EXTENSION = ".install" + BUNDLE_EXTENSION;
+    public static final String ENV_INSTALL_BUNDLE_NAME_SUFFIX = "env" + INSTALL_BUNDLE_EXTENSION;
+    public static final String FULL_INSTALL_BUNDLE_NAME_SUFFIX = "-full" + INSTALL_BUNDLE_EXTENSION;
 
     private DocumentFileUtils(DocumentTools documentTools) {
         this.documentTools = documentTools;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BuilderUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BuilderUtils.java
@@ -6,18 +6,15 @@
 
 package com.ca.apim.gateway.cagatewayconfig.util.gateway;
 
-import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilderException;
 import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadException;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.annotation.Nullable;
 import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
@@ -25,7 +22,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getChildElements;
 import static java.lang.Integer.parseInt;
@@ -162,6 +158,12 @@ public class BuilderUtils {
         }
     }
 
+    /**
+     * Removes all special characters from the string.
+     *
+     * @param str string containing spacial characters
+     * @return string without special characters.
+     */
     public static String removeAllSpecialChars(String str) {
         return REGEX_ALPHANUMERIC.matcher(str).replaceAll("");
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BuilderUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BuilderUtils.java
@@ -6,21 +6,25 @@
 
 package com.ca.apim.gateway.cagatewayconfig.util.gateway;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilderException;
 import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadException;
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.annotation.Nullable;
 import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getChildElements;
 import static java.lang.Integer.parseInt;
@@ -154,6 +158,22 @@ public class BuilderUtils {
         } catch (ParseException e) {
             throw new EntityBuilderException("Unable to parse date property (" + key + ") value: " + dateAsString);
         }
+    }
+
+    public static String generateBundleName(boolean isFullBundle, ProjectInfo projectInfo, @Nullable String entityName,
+                                            @Nullable String nameInAnnotation) {
+        if (isFullBundle) {
+            return projectInfo.getName() + "-"  + projectInfo.getVersion();
+        }
+        if (StringUtils.isNotBlank(nameInAnnotation)) {
+            return nameInAnnotation + "-" + projectInfo.getVersion();
+        }
+        return projectInfo.getName() + "-" + entityName + "-" + projectInfo.getVersion();
+    }
+
+    public static String generatePolicyBundleFileName(String bundleName, boolean isDeleteBundle) {
+        return isDeleteBundle ? bundleName + POLICY_DELETE_BUNDLE_EXTENSION :
+                bundleName + POLICY_INSTALL_BUNDLE_EXTENSION;
     }
 
     private BuilderUtils() {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BuilderUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BuilderUtils.java
@@ -166,22 +166,6 @@ public class BuilderUtils {
         return REGEX_ALPHANUMERIC.matcher(str).replaceAll("");
     }
 
-    public static String generateBundleName(boolean isFullBundle, ProjectInfo projectInfo, @Nullable String entityName,
-                                            @Nullable String nameInAnnotation) {
-        if (isFullBundle) {
-            return projectInfo.getName() + "-"  + projectInfo.getVersion();
-        }
-        if (StringUtils.isNotBlank(nameInAnnotation)) {
-            return nameInAnnotation + "-" + projectInfo.getVersion();
-        }
-        return projectInfo.getName() + "-" + entityName + "-" + projectInfo.getVersion();
-    }
-
-    public static String generatePolicyBundleFileName(String bundleName, boolean isDeleteBundle) {
-        return isDeleteBundle ? bundleName + POLICY_DELETE_BUNDLE_EXTENSION :
-                bundleName + POLICY_INSTALL_BUNDLE_EXTENSION;
-    }
-
     private BuilderUtils() {
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BuilderUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BuilderUtils.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
@@ -40,6 +41,7 @@ import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConsta
 public class BuilderUtils {
 
     private static final String DATE_VALUE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+    private static final Pattern REGEX_ALPHANUMERIC = Pattern.compile("[^A-Za-z0-9]");
 
     public static void buildAndAppendPropertiesElement(final Map<String, Object> properties, final Document document, final Element elementToAppendInto) {
         if (MapUtils.isEmpty(properties)) {
@@ -158,6 +160,10 @@ public class BuilderUtils {
         } catch (ParseException e) {
             throw new EntityBuilderException("Unable to parse date property (" + key + ") value: " + dateAsString);
         }
+    }
+
+    public static String removeAllSpecialChars(String str) {
+        return REGEX_ALPHANUMERIC.matcher(str).replaceAll("");
     }
 
     public static String generateBundleName(boolean isFullBundle, ProjectInfo projectInfo, @Nullable String entityName,

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/BundleFileBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/BundleFileBuilderTest.java
@@ -51,6 +51,8 @@ class BundleFileBuilderTest {
     @Mock
     BundleCache bundleCache;
 
+    private static final ProjectInfo projectInfo = new ProjectInfo("my-bundle", "my-bundle-group", "1.0");
+
     @BeforeEach
     void beforeEach() {
         when(documentTools.getDocumentBuilder()).thenReturn(documentBuilder);
@@ -60,11 +62,10 @@ class BundleFileBuilderTest {
     void buildBundleNoSource() {
         BundleFileBuilder bundleFileBuilder = new BundleFileBuilder(documentTools, documentFileUtils,
                 jsonFileUtils, entityLoaderRegistry, bundleEntityBuilder, bundleCache);
-        bundleFileBuilder.buildBundle(null, new File("output"), Collections.emptyList(), "my-bundle",
-                "my-bundle-group", "1.0");
+        bundleFileBuilder.buildBundle(null, new File("output"), Collections.emptyList(), projectInfo);
 
         verify(bundleEntityBuilder).build(argThat(bundle -> bundle.getPolicies().isEmpty()),
-                eq(EntityBuilder.BundleType.DEPLOYMENT), any(), eq("my-bundle"), eq("my-bundle-group"), eq("1.0"));
+                eq(EntityBuilder.BundleType.DEPLOYMENT), any(), eq(projectInfo));
     }
 
     @Test
@@ -75,11 +76,10 @@ class BundleFileBuilderTest {
 
         BundleFileBuilder bundleFileBuilder = new BundleFileBuilder(documentTools, documentFileUtils,
                 jsonFileUtils, entityLoaderRegistry, bundleEntityBuilder, bundleCache);
-        bundleFileBuilder.buildBundle(new File("input"), new File("output"),Collections.emptyList(), "my-bundle",
-                "my-bundle-group", "1.0");
+        bundleFileBuilder.buildBundle(new File("input"), new File("output"),Collections.emptyList(), projectInfo);
 
         verify(bundleEntityBuilder).build(argThat(bundle -> bundle.getPolicies().containsKey(policy.getName()) && bundle.getPolicies().containsValue(policy)),
-                eq(EntityBuilder.BundleType.DEPLOYMENT), any(), eq("my-bundle"), eq("my-bundle-group"), eq("1.0"));
+                eq(EntityBuilder.BundleType.DEPLOYMENT), any(), eq(projectInfo));
     }
 
     @Test
@@ -94,8 +94,7 @@ class BundleFileBuilderTest {
 
         BundleFileBuilder bundleFileBuilder = Mockito.spy(new BundleFileBuilder(documentTools, documentFileUtils,
                 jsonFileUtils, entityLoaderRegistry, bundleEntityBuilder, bundleCache));
-        bundleFileBuilder.buildBundle(new File("input"), new File("output"), dummyList, "my-bundle",
-                "my-bundle-group", "1.0");
+        bundleFileBuilder.buildBundle(new File("input"), new File("output"), dummyList, projectInfo);
 
         verify(bundleFileBuilder, Mockito.times(2)).logOverriddenEntities(any(Bundle.class), any(), any());
     }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
@@ -57,7 +57,7 @@ class BundleEntityBuilderTest {
     @Test
     void build() {
         BundleEntityBuilder builder = new BundleEntityBuilder(singleton(new TestEntityBuilder()),
-                new BundleDocumentBuilder(), new BundleMetadataBuilder(), entityTypeRegistry);
+                new BundleDocumentBuilder(), new BundleMetadataBuilder(ID_GENERATOR), entityTypeRegistry);
 
         final Map<String, BundleArtifacts> element = builder.build(new Bundle(), BundleType.DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
@@ -183,7 +183,8 @@ class BundleEntityBuilderTest {
     private static void buildAndValidateAnnotatedBundle(Bundle bundle, Set<EntityBuilder> entityBuilders,
                                                         String expEncassPolicyName, String expEncassPolicyAction, String expEncassName, String expEncassAction,
                                                         String expDepEncassPolicyName, String expDepEncassPolicyAction, String expDepEncassName, String expDepEncassAction) {
-        BundleEntityBuilder builder = new BundleEntityBuilder(entityBuilders, new BundleDocumentBuilder(), new BundleMetadataBuilder(), entityTypeRegistry);
+        BundleEntityBuilder builder = new BundleEntityBuilder(entityBuilders, new BundleDocumentBuilder(),
+                new BundleMetadataBuilder(ID_GENERATOR), entityTypeRegistry);
         Map<String, BundleArtifacts> bundles = builder.build(bundle, BundleType.DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
@@ -6,6 +6,7 @@
 
 package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
@@ -50,6 +51,8 @@ class BundleEntityBuilderTest {
     private static final String TEST_DEP_ENCASS_ID = "DepEncassID";
     private static final EntityTypeRegistry entityTypeRegistry = new EntityTypeRegistry(new Reflections());
 
+    private static final ProjectInfo projectInfo = new ProjectInfo("my-bundle", "my-bundle-group", "1.0");
+
     // This class is covered by testing others, so a simple testing is enough here.
     @Test
     void build() {
@@ -57,7 +60,7 @@ class BundleEntityBuilderTest {
                 new BundleDocumentBuilder(), new BundleMetadataBuilder(), entityTypeRegistry);
 
         final Map<String, BundleArtifacts> element = builder.build(new Bundle(), BundleType.DEPLOYMENT,
-                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), "my-bundle", "my-bundle-group", "1.0");
+                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(element);
     }
 
@@ -182,7 +185,7 @@ class BundleEntityBuilderTest {
                                                         String expDepEncassPolicyName, String expDepEncassPolicyAction, String expDepEncassName, String expDepEncassAction) {
         BundleEntityBuilder builder = new BundleEntityBuilder(entityBuilders, new BundleDocumentBuilder(), new BundleMetadataBuilder(), entityTypeRegistry);
         Map<String, BundleArtifacts> bundles = builder.build(bundle, BundleType.DEPLOYMENT,
-                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), "my-bundle", "my-bundle-group", "1.0");
+                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
         for (Map.Entry<String, BundleArtifacts> bundleEntry : bundles.entrySet()) {
@@ -254,7 +257,7 @@ class BundleEntityBuilderTest {
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
         Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
-                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), "my-bundle", "my-bundle-group", "1.0");
+                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
         Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle();
@@ -305,7 +308,7 @@ class BundleEntityBuilderTest {
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
         Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
-                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), "my-bundle", "my-bundle-group", "1.0");
+                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
         Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle();
@@ -375,7 +378,7 @@ class BundleEntityBuilderTest {
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
         Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
-                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), "my-bundle", "my-bundle-group", "1.0");
+                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
         Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle();
@@ -445,7 +448,7 @@ class BundleEntityBuilderTest {
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
         Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
-                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), "my-bundle", "my-bundle-group", "1.0");
+                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
         Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle();

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
@@ -294,8 +294,9 @@ public class BundleEntityBuilderTestHelper {
         assertEquals(1, bundles.size());
         BundleMetadata metadata = bundles.entrySet().iterator().next().getValue().getBundleMetadata();
         assertNotNull(metadata);
+        assertEquals("1.0", metadata.getMetaVersion());
         assertEquals("my-bundle-group", metadata.getGroupName());
-        assertEquals("encass", metadata.getType());
+        assertEquals(EntityTypes.ENCAPSULATED_ASSERTION_TYPE, metadata.getType());
         assertEquals("1.0", metadata.getVersion());
         if (isRedeployableBundle || !isBundleContainReusableEntity) {
             assertTrue(metadata.isRedeployable());

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
@@ -78,7 +78,8 @@ public class BundleEntityBuilderTestHelper {
         entityBuilders.add(clusterPropertyEntityBuilder);
         entityBuilders.add(trustedCertEntityBuilder);
 
-        return new BundleEntityBuilder(entityBuilders, new BundleDocumentBuilder(), new BundleMetadataBuilder(), entityTypeRegistry);
+        return new BundleEntityBuilder(entityBuilders, new BundleDocumentBuilder(),
+                new BundleMetadataBuilder(new IdGenerator()), entityTypeRegistry);
     }
 
     static Encass buildTestEncassWithAnnotation(String encassGuid, String policyPath, boolean isRedeployable) {

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilderTest.java
@@ -74,7 +74,7 @@ public class BundleMetadataBuilderTest {
                 if (StringUtils.endsWith(generatedFile.getName(), DELETE_BUNDLE_EXTENSION)) {
                     assertEquals(TEST_ENCASS_ANNOTATION_NAME + "-1.0-policy" + DELETE_BUNDLE_EXTENSION,
                             generatedFile.getName());
-                } else if (StringUtils.endsWith(generatedFile.getName(), BUNDLE_EXTENSION)) {
+                } else if (StringUtils.endsWith(generatedFile.getName(), INSTALL_BUNDLE_EXTENSION)) {
                     assertEquals(TEST_ENCASS_ANNOTATION_NAME + "-1.0-policy" + INSTALL_BUNDLE_EXTENSION,
                             generatedFile.getName());
                 } else {
@@ -187,7 +187,7 @@ public class BundleMetadataBuilderTest {
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
         Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
-                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), "my-bundle", "my-bundle-group", "1.0");
+                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), new ProjectInfo("my-bundle", "my-bundle-group", "1.0"));
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
         BundleMetadata metadata = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getBundleMetadata();

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilderTest.java
@@ -7,6 +7,7 @@
 package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
 import com.ca.apim.gateway.cagatewayconfig.BundleFileBuilder;
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
 import com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoader;
 import com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoaderRegistry;
@@ -29,8 +30,7 @@ import java.io.File;
 import java.util.*;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleEntityBuilderTestHelper.*;
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.BUNDLE_EXTENSION;
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.DELETE_BUNDLE_EXTENSION;
+import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.JsonFileUtils.METADATA_FILE_NAME_SUFFIX;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,6 +44,8 @@ public class BundleMetadataBuilderTest {
     EntityLoaderRegistry entityLoaderRegistry;
     @Mock
     BundleCache bundleCache;
+
+    private static final ProjectInfo projectInfo = new ProjectInfo("my-bundle", "my-bundle-group", "1.0");
 
     @Test
     public void testAnnotatedEncassBundleFileNames(final TemporaryFolder temporaryFolder) {
@@ -64,17 +66,17 @@ public class BundleMetadataBuilderTest {
 
         File bundleOutput = temporaryFolder.createDirectory("output");
         try {
-            bundleFileBuilder.buildBundle(temporaryFolder.getRoot(), bundleOutput, dummyList,
-                    "my-bundle", "my-bundle-group", "1.0");
+            bundleFileBuilder.buildBundle(temporaryFolder.getRoot(), bundleOutput, dummyList, projectInfo);
 
             assertTrue(bundleOutput.exists());
             assertEquals(3, bundleOutput.listFiles().length);
             for (File generatedFile : bundleOutput.listFiles()) {
                 if (StringUtils.endsWith(generatedFile.getName(), DELETE_BUNDLE_EXTENSION)) {
-                    assertEquals(TEST_ENCASS_ANNOTATION_NAME + "-1.0" + DELETE_BUNDLE_EXTENSION,
+                    assertEquals(TEST_ENCASS_ANNOTATION_NAME + "-1.0-policy" + DELETE_BUNDLE_EXTENSION,
                             generatedFile.getName());
                 } else if (StringUtils.endsWith(generatedFile.getName(), BUNDLE_EXTENSION)) {
-                    assertEquals(TEST_ENCASS_ANNOTATION_NAME + "-1.0" + BUNDLE_EXTENSION, generatedFile.getName());
+                    assertEquals(TEST_ENCASS_ANNOTATION_NAME + "-1.0-policy" + INSTALL_BUNDLE_EXTENSION,
+                            generatedFile.getName());
                 } else {
                     assertEquals(TEST_ENCASS_ANNOTATION_NAME + "-1.0" + METADATA_FILE_NAME_SUFFIX,
                             generatedFile.getName());
@@ -95,18 +97,18 @@ public class BundleMetadataBuilderTest {
 
         bundleOutput = temporaryFolder.createDirectory("output");
         try {
-            bundleFileBuilder.buildBundle(temporaryFolder.getRoot(), bundleOutput, dummyList, "my-bundle",
-                    "my-bundle-group", "1.0");
+            bundleFileBuilder.buildBundle(temporaryFolder.getRoot(), bundleOutput, dummyList, projectInfo);
 
             bundleOutput = new File(temporaryFolder.getRoot(), "output");
             assertTrue(bundleOutput.exists());
             assertEquals(3, bundleOutput.listFiles().length);
             for (File generatedFile : bundleOutput.listFiles()) {
-                if (StringUtils.endsWith(generatedFile.getName(), ".delete.bundle")) {
-                    assertEquals("my-bundle-" + encass.getName() + "-1.0" + DELETE_BUNDLE_EXTENSION,
+                if (StringUtils.endsWith(generatedFile.getName(), DELETE_BUNDLE_EXTENSION)) {
+                    assertEquals("my-bundle-" + encass.getName() + "-1.0-policy" + DELETE_BUNDLE_EXTENSION,
                             generatedFile.getName());
                 } else if (StringUtils.endsWith(generatedFile.getName(), ".bundle")) {
-                    assertEquals("my-bundle-" + encass.getName() + "-1.0" + BUNDLE_EXTENSION, generatedFile.getName());
+                    assertEquals("my-bundle-" + encass.getName() + "-1.0-policy" + INSTALL_BUNDLE_EXTENSION,
+                            generatedFile.getName());
                 } else {
                     assertEquals("my-bundle-" + encass.getName() + "-1.0" + METADATA_FILE_NAME_SUFFIX,
                             generatedFile.getName());
@@ -126,7 +128,7 @@ public class BundleMetadataBuilderTest {
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
         Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
-                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), "my-bundle", "my-bundle-group", "1.0");
+                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
         BundleMetadata metadata = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getBundleMetadata();
@@ -156,7 +158,7 @@ public class BundleMetadataBuilderTest {
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
         Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
-                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), "my-bundle", "my-bundle-group", "1.0");
+                DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
         BundleMetadata metadata = bundles.get("my-bundle-" + encass.getName() + "-1.0").getBundleMetadata();

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilderTest.java
@@ -6,6 +6,7 @@
 
 package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
@@ -75,7 +76,7 @@ class EncassEntityBuilderTest {
         policy.setId(TEST_POLICY_ID);
         bundle.getPolicies().put(TEST_POLICY_PATH, policy);
         AnnotatedEntity annotatedEntity = new AnnotatedEntity(encass);
-        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity);
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, null);
         annotatedBundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
         annotatedBundle.getPolicies().put(TEST_POLICY_PATH, policy);
         List<Entity> entities = builder.build(annotatedBundle, BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
@@ -98,7 +99,7 @@ class EncassEntityBuilderTest {
         encass.setAnnotations(annotations);
         encass.setAnnotatedEntity(null);
         annotatedEntity = new AnnotatedEntity(encass);
-        annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity);
+        annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, null);
         annotatedBundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
         annotatedBundle.getPolicies().put(TEST_POLICY_PATH, policy);
         entities = builder.build(annotatedBundle, BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilderTest.java
@@ -6,6 +6,7 @@
 
 package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
@@ -157,7 +158,7 @@ class PolicyEntityBuilderTest {
 
         AnnotatedEntity annotatedEntity = new AnnotatedEntity(encass);
         annotatedEntity.setEntityName(encass.getName());
-        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity);
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, new ProjectInfo("", "", ""));
         annotatedBundle.putAllEncasses(org.testcontainers.shaded.com.google.common.collect.ImmutableMap.of(TEST_ENCASS, encass));
         annotatedBundle.getPolicies().put("Policy", policy);
 
@@ -375,7 +376,7 @@ class PolicyEntityBuilderTest {
 
         //empty guid and goid
         AnnotatedEntity annotatedEntity = new AnnotatedEntity(encass);
-        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity);
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, null);
         annotatedBundle.putAllEncasses(org.testcontainers.shaded.com.google.common.collect.ImmutableMap.of(TEST_ENCASS, encass));
         annotatedBundle.getPolicies().put(policyPath, policy);
         Element encapsulatedAssertionElement = createEncapsulatedAssertionElement(document);
@@ -399,7 +400,7 @@ class PolicyEntityBuilderTest {
         annotations.add(annotation);
         encass.setAnnotations(annotations);
         encass.setAnnotatedEntity(null);
-        annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity);
+        annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, null);
         annotatedBundle.putAllEncasses(org.testcontainers.shaded.com.google.common.collect.ImmutableMap.of(TEST_ENCASS, encass));
         annotatedBundle.getPolicies().put(policyPath, policy);
         encapsulatedAssertionElement = createEncapsulatedAssertionElement(document);

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildDeploymentBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildDeploymentBundleTask.java
@@ -59,8 +59,9 @@ public class BuildDeploymentBundleTask extends DefaultTask {
     @TaskAction
     public void perform() {
         BundleFileBuilder bundleFileBuilder = InjectionRegistry.getInjector().getInstance(BundleFileBuilder.class);
+        final ProjectInfo projectInfo = new ProjectInfo(getProject().getName(), getProject().getGroup().toString(),
+                getProject().getVersion().toString());
         bundleFileBuilder.buildBundle(from.isPresent() ? from.getAsFile().get() : null, into.getAsFile().get(),
-                new ArrayList<>(dependencies.getFiles()) , getProject().getName(),
-                getProject().getGroup().toString(), getProject().getVersion().toString());
+                new ArrayList<>(dependencies.getFiles()), projectInfo);
     }
 }

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.PLUGIN;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.ENV_INSTALL_BUNDLE_NAME_SUFFIX;
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.removeAllSpecialChars;
 import static com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry.getInstance;
@@ -101,11 +100,25 @@ public class BuildEnvironmentBundleTask extends DefaultTask {
         });
     }
 
+    /**
+     * Generates the Environment install bundle filename in the format <name>-<version>-*env.install.bundle.
+     *
+     * Here "-*env" is generated with the following preference:
+     * 1) If "configName" is provided in the GatewaySourceConfig {} in build.gradle, "configName" will be used after
+     * removing all the special characters. For eg. if "configName" is set "default", filename will have "-defaultenv"
+     * 2) If "configName" is not provided, check "configFolder" name (not path).
+     *    2.1) If "configFolder" is the default folder (i.e "src/main/gateway/config"), directly use "-env".
+     *    2.2) If configFolder is not the default folder, use folder name after removing all the special characters.
+     *    For eg. "configFolder" is set as "src/main/gateway/config-staging", filename will have "-configstagingenv"
+     *
+     * @param deployBundleName bundle name prefix obtained from project name and version or from annotations
+     * @return Environment install bundle filename
+     */
     private String getEnvBundleFilename(String deployBundleName) {
         if (configName != null && StringUtils.isNotBlank(configName.get())) {
             return deployBundleName + "-" + removeAllSpecialChars(configName.get()) + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
         } else {
-            String configFolderName = configFolder != null && configFolder.isPresent()?
+            String configFolderName = configFolder != null && configFolder.isPresent() ?
                     configFolder.getAsFile().get().getName() : "";
             if (StringUtils.equalsIgnoreCase(configFolderName, "config")) {
                 return deployBundleName + "-" + ENV_INSTALL_BUNDLE_NAME_SUFFIX;

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
@@ -105,7 +105,8 @@ public class BuildEnvironmentBundleTask extends DefaultTask {
         if (configName != null && StringUtils.isNotBlank(configName.get())) {
             return deployBundleName + "-" + removeAllSpecialChars(configName.get()) + extension;
         } else {
-            String configFolderName = configFolder != null ? configFolder.getAsFile().get().getName() : "";
+            String configFolderName = configFolder != null && configFolder.isPresent()?
+                    configFolder.getAsFile().get().getName() : "";
             if (StringUtils.equalsIgnoreCase(configFolderName, "config")) {
                 return deployBundleName + "-" + extension;
             } else {

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
@@ -78,14 +78,14 @@ public class BuildEnvironmentBundleTask extends DefaultTask {
         metaDataFiles.stream().forEach(metaDataFile-> {
             final Pair<String, Map<String, String>> bundleEnvironmentValues = environmentConfigurationUtils.parseBundleMetadata(metaDataFile, configFolder.getAsFile().get());
             if (null != bundleEnvironmentValues) {
-                final String envBundleFilenameWithSuffix = getEnvBundleFileName(bundleEnvironmentValues.getLeft());
+                final String envBundleFilename = getEnvBundleFileName(bundleEnvironmentValues.getLeft());
                 environmentBundleCreator.createEnvironmentBundle(
                         bundleEnvironmentValues.getRight(),
                         into.getAsFile().get().getPath(),
                         into.getAsFile().get().getPath(),
                         EMPTY,
                         PLUGIN,
-                        envBundleFilenameWithSuffix, // Passing envBundleFilenameWithSuffix
+                        envBundleFilename, // Passing envBundleFilename
                         bundleEnvironmentValues.getLeft()
                 );
             }

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
@@ -9,7 +9,6 @@ package com.ca.apim.gateway.cagatewayconfig;
 import com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreator;
 import com.ca.apim.gateway.cagatewayconfig.environment.MissingEnvironmentException;
 import com.ca.apim.gateway.cagatewayconfig.util.environment.EnvironmentConfigurationUtils;
-import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.gradle.api.DefaultTask;
@@ -26,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.PLUGIN;
+import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.ENV_INSTALL_BUNDLE_NAME_SUFFIX;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.removeAllSpecialChars;
 import static com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry.getInstance;
@@ -93,15 +93,14 @@ public class BuildEnvironmentBundleTask extends DefaultTask {
     }
 
     private String getEnvBundleFileName(String deployBundleName) {
-        final String extension = "env" + DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
         if (configName != null && StringUtils.isNotBlank(configName.get())) {
-            return deployBundleName + "-" + removeAllSpecialChars(configName.get()) + extension;
+            return deployBundleName + "-" + removeAllSpecialChars(configName.get()) + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
         } else {
             String configFolderName = configFolder != null ? configFolder.getAsFile().get().getName() : "";
             if (StringUtils.equalsIgnoreCase(configFolderName, "config")) {
-                return deployBundleName + "-" + extension;
+                return deployBundleName + "-" + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
             } else {
-                return deployBundleName + "-" + removeAllSpecialChars(configFolderName) + extension;
+                return deployBundleName + "-" + removeAllSpecialChars(configFolderName) + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
             }
         }
     }

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.PLUGIN;
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.ENV_INSTALL_BUNDLE_NAME_SUFFIX;
+import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.removeAllSpecialChars;
 import static com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry.getInstance;
@@ -83,7 +83,7 @@ public class BuildEnvironmentBundleTask extends DefaultTask {
         metaDataFiles.stream().forEach(metaDataFile -> {
             final Pair<String, Map<String, String>> bundleEnvironmentValues = environmentConfigurationUtils.parseBundleMetadata(metaDataFile, configFolder.getAsFile().getOrNull());
             if (null != bundleEnvironmentValues) {
-                final String envBundleFilename = getEnvBundleFileName(bundleEnvironmentValues.getLeft());
+                final String envBundleFileName = getEnvBundleFilename(bundleEnvironmentValues.getLeft());
                 Map<String, String> environmentValuesFromMetadata = bundleEnvironmentValues.getRight();
                 //read environment properties from environmentConfig and merge it with metadata properties
                 environmentValuesFromMetadata.putAll(environmentConfigurationUtils.parseEnvironmentValues(environmentConfig.get()));
@@ -93,22 +93,23 @@ public class BuildEnvironmentBundleTask extends DefaultTask {
                         into.getAsFile().get().getPath(),
                         EMPTY,
                         PLUGIN,
-                        envBundleFilename, // Passing envBundleFilename
+                        envBundleFileName, // Passing envBundleFileName
                         bundleEnvironmentValues.getLeft()
                 );
             }
         });
     }
 
-    private String getEnvBundleFileName(String deployBundleName) {
+    private String getEnvBundleFilename(String deployBundleName) {
+        final String extension = "env" + INSTALL_BUNDLE_EXTENSION;
         if (configName != null && StringUtils.isNotBlank(configName.get())) {
-            return deployBundleName + "-" + removeAllSpecialChars(configName.get()) + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
+            return deployBundleName + "-" + removeAllSpecialChars(configName.get()) + extension;
         } else {
             String configFolderName = configFolder != null ? configFolder.getAsFile().get().getName() : "";
             if (StringUtils.equalsIgnoreCase(configFolderName, "config")) {
-                return deployBundleName + "-" + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
+                return deployBundleName + "-" + extension;
             } else {
-                return deployBundleName + "-" + removeAllSpecialChars(configFolderName) + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
+                return deployBundleName + "-" + removeAllSpecialChars(configFolderName) + extension;
             }
         }
     }

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
@@ -9,6 +9,7 @@ package com.ca.apim.gateway.cagatewayconfig;
 import com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreator;
 import com.ca.apim.gateway.cagatewayconfig.environment.MissingEnvironmentException;
 import com.ca.apim.gateway.cagatewayconfig.util.environment.EnvironmentConfigurationUtils;
+import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.gradle.api.DefaultTask;
@@ -23,10 +24,10 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.PLUGIN;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.removeAllSpecialChars;
 import static com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry.getInstance;
 import static com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools.YML_EXTENSION;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -36,7 +37,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
  */
 public class BuildEnvironmentBundleTask extends DefaultTask {
 
-    private static final Pattern REGEX_ALPHANUMERIC = Pattern.compile("[^A-Za-z0-9]");
+
 
     private final DirectoryProperty into;
     private final EnvironmentConfigurationUtils environmentConfigurationUtils;
@@ -92,19 +93,16 @@ public class BuildEnvironmentBundleTask extends DefaultTask {
     }
 
     private String getEnvBundleFileName(String deployBundleName) {
+        final String extension = "env" + DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
         if (configName != null && StringUtils.isNotBlank(configName.get())) {
-            return deployBundleName + "-" + removeAllSpecialChars(configName.get()) + "env";
+            return deployBundleName + "-" + removeAllSpecialChars(configName.get()) + extension;
         } else {
             String configFolderName = configFolder != null ? configFolder.getAsFile().get().getName() : "";
             if (StringUtils.equalsIgnoreCase(configFolderName, "config")) {
-                return deployBundleName + "-env";
+                return deployBundleName + "-" + extension;
             } else {
-                return deployBundleName + "-" + removeAllSpecialChars(configFolderName) + "env";
+                return deployBundleName + "-" + removeAllSpecialChars(configFolderName) + extension;
             }
         }
-    }
-
-    private String removeAllSpecialChars(String str) {
-        return REGEX_ALPHANUMERIC.matcher(str).replaceAll("");
     }
 }

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.PLUGIN;
+import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.ENV_INSTALL_BUNDLE_NAME_SUFFIX;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.removeAllSpecialChars;
@@ -101,16 +102,15 @@ public class BuildEnvironmentBundleTask extends DefaultTask {
     }
 
     private String getEnvBundleFilename(String deployBundleName) {
-        final String extension = "env" + INSTALL_BUNDLE_EXTENSION;
         if (configName != null && StringUtils.isNotBlank(configName.get())) {
-            return deployBundleName + "-" + removeAllSpecialChars(configName.get()) + extension;
+            return deployBundleName + "-" + removeAllSpecialChars(configName.get()) + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
         } else {
             String configFolderName = configFolder != null && configFolder.isPresent()?
                     configFolder.getAsFile().get().getName() : "";
             if (StringUtils.equalsIgnoreCase(configFolderName, "config")) {
-                return deployBundleName + "-" + extension;
+                return deployBundleName + "-" + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
             } else {
-                return deployBundleName + "-" + removeAllSpecialChars(configFolderName) + extension;
+                return deployBundleName + "-" + removeAllSpecialChars(configFolderName) + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
             }
         }
     }

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
@@ -101,6 +101,10 @@ public class BuildFullBundleTask extends DefaultTask {
                 final String fullInstallBundleFilename = bundleEnvironmentValues.getLeft() + FULL_INSTALL_BUNDLE_NAME_SUFFIX;
                 //read environment properties from environmentConfig and merge it with metadata properties
                 bundleEnvironmentValues.getRight().putAll(environmentConfigurationUtils.parseEnvironmentValues(environmentConfig.get()));
+                final List<File> bundleFiles = union(
+                        collectFiles(bundleDirectory, bundleEnvironmentValues.getLeft() + INSTALL_BUNDLE_EXTENSION),
+                        filterBundleFiles(dependencyBundles.getAsFileTree().getFiles())
+                );
                 fullBundleCreator.createFullBundle(
                         bundleEnvironmentValues,
                         filterBundleFiles(dependencyBundles.getAsFileTree().getFiles()),

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
@@ -23,11 +23,9 @@ import java.util.Map;
 
 import static com.ca.apim.gateway.cagatewayconfig.ProjectDependencyUtils.filterBundleFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.FULL_INSTALL_BUNDLE_NAME_SUFFIX;
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry.getInstance;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.JsonFileUtils.METADATA_FILE_NAME_SUFFIX;
-import static org.apache.commons.collections4.ListUtils.union;
 
 /**
  * The BuildFullBundleTask task will grab provided environment properties and build a single bundle merged with the deployment bundles.

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.ca.apim.gateway.cagatewayconfig.ProjectDependencyUtils.filterBundleFiles;
+import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.FULL_INSTALL_BUNDLE_NAME_SUFFIX;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry.getInstance;
@@ -86,7 +87,7 @@ public class BuildFullBundleTask extends DefaultTask {
         metaDataFiles.stream().forEach(metaDataFile-> {
             final Pair<String, Map<String, String>> bundleEnvironmentValues = environmentConfigurationUtils.parseBundleMetadata(metaDataFile, configFolder.getAsFile().get());
             if (null != bundleEnvironmentValues) {
-                final String bundleFileName = bundleEnvironmentValues.getLeft() + "-full" + INSTALL_BUNDLE_EXTENSION;
+                final String bundleFileName = bundleEnvironmentValues.getLeft() + FULL_INSTALL_BUNDLE_NAME_SUFFIX;
                 final List<File> bundleFiles = union(
                         collectFiles(bundleDirectory, INSTALL_BUNDLE_EXTENSION),
                         filterBundleFiles(dependencyBundles.getAsFileTree().getFiles())

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
@@ -101,10 +101,6 @@ public class BuildFullBundleTask extends DefaultTask {
                 final String fullInstallBundleFilename = bundleEnvironmentValues.getLeft() + FULL_INSTALL_BUNDLE_NAME_SUFFIX;
                 //read environment properties from environmentConfig and merge it with metadata properties
                 bundleEnvironmentValues.getRight().putAll(environmentConfigurationUtils.parseEnvironmentValues(environmentConfig.get()));
-                final List<File> bundleFiles = union(
-                        collectFiles(bundleDirectory, bundleEnvironmentValues.getLeft() + INSTALL_BUNDLE_EXTENSION),
-                        filterBundleFiles(dependencyBundles.getAsFileTree().getFiles())
-                );
                 fullBundleCreator.createFullBundle(
                         bundleEnvironmentValues,
                         filterBundleFiles(dependencyBundles.getAsFileTree().getFiles()),

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
@@ -98,19 +98,14 @@ public class BuildFullBundleTask extends DefaultTask {
         metaDataFiles.stream().forEach(metaDataFile-> {
             final Pair<String, Map<String, String>> bundleEnvironmentValues = environmentConfigurationUtils.parseBundleMetadata(metaDataFile, configFolder.getAsFile().getOrNull());
             if (null != bundleEnvironmentValues) {
-                final String bundleFileName = bundleEnvironmentValues.getLeft() + FULL_INSTALL_BUNDLE_NAME_SUFFIX;
+                final String fullInstallBundleFilename = bundleEnvironmentValues.getLeft() + FULL_INSTALL_BUNDLE_NAME_SUFFIX;
                 //read environment properties from environmentConfig and merge it with metadata properties
                 bundleEnvironmentValues.getRight().putAll(environmentConfigurationUtils.parseEnvironmentValues(environmentConfig.get()));
-                final List<File> bundleFiles = union(
-                        collectFiles(bundleDirectory, INSTALL_BUNDLE_EXTENSION),
-                        filterBundleFiles(dependencyBundles.getAsFileTree().getFiles())
-                );
-
                 fullBundleCreator.createFullBundle(
                         bundleEnvironmentValues,
                         filterBundleFiles(dependencyBundles.getAsFileTree().getFiles()),
                         bundleDirectory,
-                        bundleFileName,
+                        fullInstallBundleFilename,
                         detemplatizeDeploymentBundles.get()
                 );
             }

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import static com.ca.apim.gateway.cagatewayconfig.ProjectDependencyUtils.filterBundleFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.BUNDLE_EXTENSION;
+import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry.getInstance;
 import static com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools.YML_EXTENSION;
@@ -88,7 +89,7 @@ public class BuildFullBundleTask extends DefaultTask {
             if (null != bundleEnvironmentValues) {
                 final String bundleFileName = bundleEnvironmentValues.getLeft() + "." + configName.get() + ".full.bundle";
                 final List<File> bundleFiles = union(
-                        collectFiles(bundleDirectory, bundleEnvironmentValues.getLeft() + BUNDLE_EXTENSION),
+                        collectFiles(bundleDirectory, INSTALL_BUNDLE_EXTENSION),
                         filterBundleFiles(dependencyBundles.getAsFileTree().getFiles())
                 );
 

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.ca.apim.gateway.cagatewayconfig.ProjectDependencyUtils.filterBundleFiles;
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.BUNDLE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry.getInstance;
@@ -87,7 +86,7 @@ public class BuildFullBundleTask extends DefaultTask {
         metaDataFiles.stream().forEach(metaDataFile-> {
             final Pair<String, Map<String, String>> bundleEnvironmentValues = environmentConfigurationUtils.parseBundleMetadata(metaDataFile, configFolder.getAsFile().get());
             if (null != bundleEnvironmentValues) {
-                final String bundleFileName = bundleEnvironmentValues.getLeft() + "." + configName.get() + ".full.bundle";
+                final String bundleFileName = bundleEnvironmentValues.getLeft() + "-full" + INSTALL_BUNDLE_EXTENSION;
                 final List<File> bundleFiles = union(
                         collectFiles(bundleDirectory, INSTALL_BUNDLE_EXTENSION),
                         filterBundleFiles(dependencyBundles.getAsFileTree().getFiles())

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/CAGatewayDeveloper.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/CAGatewayDeveloper.java
@@ -151,11 +151,11 @@ public class CAGatewayDeveloper implements Plugin<Project> {
         final String artifactName = getBuiltArtifactName(project, "." + pluginConfig.getConfigName() + ".environment", BUNDLE_FILE_EXTENSION);
         if (project.getGradle().getStartParameter().getTaskNames().contains(BUILD_ENVIRONMENT_BUNDLE)) {
             project.artifacts(artifactHandler -> addBundleArtifact(
-                artifactHandler,
-                pluginConfig.getBuiltBundleDir().file(new DefaultProvider<>(() -> artifactName)),
-                buildEnvironmentBundleTask,
-                project::getName,
-                "environment"));
+                    artifactHandler,
+                    pluginConfig.getBuiltBundleDir().file(new DefaultProvider<>(() -> artifactName)),
+                    buildEnvironmentBundleTask,
+                    project::getName,
+                    "environment"));
         }
         // add the full bundle to the artifacts only if the full bundle task was triggered
         final String fullBundleArtifactName = getBuiltArtifactName(project, "." + pluginConfig.getConfigName() + ".full", BUNDLE_FILE_EXTENSION);
@@ -225,7 +225,7 @@ public class CAGatewayDeveloper implements Plugin<Project> {
             pluginConfig.getConfigFolder().set(new File(project.getProjectDir(),"src/main/gateway/config"));
         }
         if (!pluginConfig.getConfigName().isPresent()) {
-            pluginConfig.getConfigName().set("");
+            pluginConfig.getConfigName().set("config");
         }
     }
 }

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/CAGatewayDeveloper.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/CAGatewayDeveloper.java
@@ -225,7 +225,7 @@ public class CAGatewayDeveloper implements Plugin<Project> {
             pluginConfig.getConfigFolder().set(new File(project.getProjectDir(),"src/main/gateway/config"));
         }
         if (!pluginConfig.getConfigName().isPresent()) {
-            pluginConfig.getConfigName().set("config");
+            pluginConfig.getConfigName().set("");
         }
     }
 }

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/CAGatewayDeveloper.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/CAGatewayDeveloper.java
@@ -127,7 +127,7 @@ public class CAGatewayDeveloper implements Plugin<Project> {
         return project.getTasks().create("package-gw7", PackageTask.class, t -> {
             t.dependsOn(buildDeploymentBundleTask);
             t.getInto().set(new DefaultProvider<RegularFile>(() -> () -> new File(new File(project.getBuildDir(), GATEWAY_BUILD_DIRECTORY), getBuiltArtifactName(project, EMPTY,"gw7"))));
-            t.getBundle().set(pluginConfig.getBuiltBundleDir().file(new DefaultProvider<>(() -> getBuiltArtifactName(project, EMPTY, BUNDLE_FILE_EXTENSION))));
+            t.getBundle().set(pluginConfig.getBuiltBundleDir().file(new DefaultProvider<>(() -> getBuiltArtifactName(project, "-policy.install", BUNDLE_FILE_EXTENSION))));
             t.getDependencyBundles().setFrom(project.getConfigurations().getByName(BUNDLE_CONFIGURATION));
             t.getContainerApplicationDependencies().setFrom(project.getConfigurations().getByName(ENV_APPLICATION_CONFIGURATION));
             t.getDependencyModularAssertions().setFrom(project.getConfigurations().getByName(MODULAR_ASSERTION_CONFIGURATION));

--- a/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
+++ b/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
@@ -400,8 +400,8 @@ class CAGatewayDeveloperTest {
         bundleItemsIds.addAll(getChildElements(getSingleChildElement(dependencyBundle, REFERENCES), ITEM).stream().map(EnvironmentBundleUtils::buildBundleItemKey).collect(toSet()));
         bundleMappingsIds.addAll(getChildElements(getSingleChildElement(dependencyBundle, MAPPINGS), MAPPING).stream().map(EnvironmentBundleUtils::buildBundleMappingKey).collect(toSet()));
 
-        //Full bundle name format : <bundleName>-<version>.(<configName>.)full.bundle
-        File builtFullBundleFile = new File(new File(buildGatewayDir, "bundle"), bundleName + projectVersion + ".config" + ".full.bundle");
+        //Full bundle name format : <bundleName>-<version>-full.install.bundle
+        File builtFullBundleFile = new File(new File(buildGatewayDir, "bundle"), bundleName + projectVersion + "-full" + INSTALL_BUNDLE_EXTENSION);
         assertTrue(builtFullBundleFile.isFile());
 
         final Element fullBundleElement = DocumentTools.INSTANCE.parse(builtFullBundleFile).getDocumentElement();

--- a/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
+++ b/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
@@ -7,7 +7,6 @@
 package com.ca.apim.gateway.capublisherplugin;
 
 import com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleUtils;
-import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import io.github.glytching.junit.extension.folder.TemporaryFolder;
@@ -39,13 +38,12 @@ import java.util.zip.GZIPInputStream;
 
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleUtils.buildBundleItemKey;
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleUtils.buildBundleMappingKey;
-import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
+import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
 import static java.nio.charset.Charset.defaultCharset;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.io.FileUtils.readFileToString;
-import static org.gradle.internal.impldep.org.apache.maven.artifact.repository.metadata.RepositoryMetadata.SNAPSHOT;
 import static org.junit.jupiter.api.Assertions.*;
 
 class CAGatewayDeveloperTest {
@@ -269,7 +267,7 @@ class CAGatewayDeveloperTest {
         File buildGatewayDir = validateBuildDirExceptGW7File(bundleFilename, buildDir);
 
         //Environment bundle name format : <bundleName>-<version>-[<configName>]env.install.bundle
-        String envBundleFilename = bundleName + projectVersion + "-configenv" + INSTALL_BUNDLE_EXTENSION;
+        String envBundleFilename = bundleName + projectVersion + "-config" + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
         File builtBundleFile = new File(new File(buildGatewayDir, "bundle"), envBundleFilename);
         assertTrue(builtBundleFile.isFile());
     }
@@ -401,7 +399,7 @@ class CAGatewayDeveloperTest {
         bundleMappingsIds.addAll(getChildElements(getSingleChildElement(dependencyBundle, MAPPINGS), MAPPING).stream().map(EnvironmentBundleUtils::buildBundleMappingKey).collect(toSet()));
 
         //Full bundle name format : <bundleName>-<version>-full.install.bundle
-        File builtFullBundleFile = new File(new File(buildGatewayDir, "bundle"), bundleName + projectVersion + "-full" + INSTALL_BUNDLE_EXTENSION);
+        File builtFullBundleFile = new File(new File(buildGatewayDir, "bundle"), bundleName + projectVersion + FULL_INSTALL_BUNDLE_NAME_SUFFIX);
         assertTrue(builtFullBundleFile.isFile());
 
         final Element fullBundleElement = DocumentTools.INSTANCE.parse(builtFullBundleFile).getDocumentElement();

--- a/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
+++ b/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
@@ -8,7 +8,6 @@ package com.ca.apim.gateway.capublisherplugin;
 
 import com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
-import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import io.github.glytching.junit.extension.folder.TemporaryFolder;
@@ -50,6 +49,9 @@ import static org.junit.jupiter.api.Assertions.*;
 class CAGatewayDeveloperTest {
     private static final Logger LOGGER = Logger.getLogger(CAGatewayDeveloperTest.class.getName());
     private final String projectVersion = "-1.2.3-SNAPSHOT";
+    private final String POLICY_INSTALL_BUNDLE_SUFFIX = "-policy" + INSTALL_BUNDLE_EXTENSION;
+    private final String ENV_INSTALL_BUNDLE_SUFFIX = "env" + INSTALL_BUNDLE_EXTENSION;
+    private final String ENV_DELETE_BUNDLE_SUFFIX = "env" + DELETE_BUNDLE_EXTENSION;
 
     @Test
     @ExtendWith(TemporaryFolderExtension.class)
@@ -69,13 +71,14 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":build")).getOutcome());
 
         File buildDir = new File(testProjectDir, "build");
-        String bundleFileName = projectFolder + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String bundleFileName = projectFolder + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
         validateBuildDir(projectFolder, bundleFileName, buildDir);
         File buildGatewayDir = new File(buildDir, "gateway");
         File buildGatewayBundlesDir = new File(buildGatewayDir, "bundle");
-        File builtBundleFile = new File(buildGatewayBundlesDir,  projectFolder + projectVersion + ".bundle");
+        File builtBundleFile = new File(buildGatewayBundlesDir,  bundleFileName);
         assertTrue(builtBundleFile.isFile());
-        File builtDeleteBundleFile = new File(buildGatewayBundlesDir,  projectFolder + projectVersion + DocumentFileUtils.DELETE_BUNDLE_EXTENSION);
+        String deleteBundleFileName = projectFolder + projectVersion + "-policy" + DELETE_BUNDLE_EXTENSION;
+        File builtDeleteBundleFile = new File(buildGatewayBundlesDir,  deleteBundleFileName);
         assertTrue(builtDeleteBundleFile.isFile());
     }
 
@@ -98,7 +101,7 @@ class CAGatewayDeveloperTest {
 
         File buildGatewayDir = new File(testProjectDir, "dist");
         assertTrue(buildGatewayDir.isDirectory());
-        String bundleFileName = projectFolder + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String bundleFileName = projectFolder + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
         File builtBundleFile = new File(buildGatewayDir, bundleFileName);
         assertTrue(builtBundleFile.isFile());
     }
@@ -135,7 +138,7 @@ class CAGatewayDeveloperTest {
                 .build();
 
         assertMultiProject(testProjectDir, result);
-        File projectC_EnvBundle = new File(new File(new File(new File(new File(testProjectDir, "project-c"), "build"), "gateway"), "bundle"), "project-c" + projectVersion + "-env.install.bundle");
+        File projectC_EnvBundle = new File(new File(new File(new File(new File(testProjectDir, "project-c"), "build"), "gateway"), "bundle"), "project-c" + projectVersion + "-" + ENV_INSTALL_BUNDLE_SUFFIX);
         assertTrue(projectC_EnvBundle.exists());
         assertFalse(readFileToString(projectC_EnvBundle, defaultCharset()).isEmpty());
     }
@@ -155,7 +158,7 @@ class CAGatewayDeveloperTest {
                 .build();
 
         assertMultiProject(testProjectDir, result);
-        File projectE_EnvBundle = new File(new File(new File(new File(new File(testProjectDir, "project-e"), "build"), "gateway"), "bundle"), "project-e" + projectVersion + "-env.install.bundle");
+        File projectE_EnvBundle = new File(new File(new File(new File(new File(testProjectDir, "project-e"), "build"), "gateway"), "bundle"), "project-e" + projectVersion + "-" + ENV_INSTALL_BUNDLE_SUFFIX);
         assertTrue(projectE_EnvBundle.exists());
         assertFalse(readFileToString(projectE_EnvBundle, defaultCharset()).isEmpty());
         final Element envBundleElement = DocumentTools.INSTANCE.parse(projectE_EnvBundle).getDocumentElement();
@@ -186,10 +189,10 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":project-a:build")).getOutcome());
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":project-b:build")).getOutcome());
 
-        String projectAFilename = "project-a" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
-        String projectBFilename = "project-b" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
-        String projectCFilename = "project-c" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
-        String projectDFilename = "project-d" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String projectAFilename = "project-a" + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
+        String projectBFilename = "project-b" + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
+        String projectCFilename = "project-c" + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
+        String projectDFilename = "project-d" + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
         validateBuildDir("project-a", projectAFilename, new File(new File(testProjectDir, "project-a"), "build"));
         validateBuildDir("project-b" , projectBFilename, new File(new File(testProjectDir, "project-b"), "build"));
         validateBuildDir("project-c" , projectCFilename, new File(new File(testProjectDir, "project-c"), "build"));
@@ -228,7 +231,7 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":build")).getOutcome());
 
         File buildDir = new File(testProjectDir, "build");
-        String bundleFileName = projectFolder + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String bundleFileName = projectFolder + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
         File gw7 = validateBuildDir(projectFolder, bundleFileName, buildDir);
 
         TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(gw7)));
@@ -261,9 +264,9 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":project-a:build")).getOutcome());
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":project-b:build")).getOutcome());
 
-        String projectAFilename = "project-a" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
-        String projectBFilename = "project-b" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
-        String projectCFilename = "project-c" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String projectAFilename = "project-a" + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
+        String projectBFilename = "project-b" + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
+        String projectCFilename = "project-c" + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
         validateBuildDir("project-a" , projectAFilename, new File(new File(testProjectDir, "project-a"), "build"));
         validateBuildDir("project-b" , projectBFilename, new File(new File(testProjectDir, "project-b"), "build"));
         validateBuildDir("project-c" , projectCFilename, new File(new File(testProjectDir, "project-c"), "build"));
@@ -308,12 +311,12 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":build-bundle")).getOutcome());
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":build-environment-bundle")).getOutcome());
 
-        String bundleFilename = bundleName + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String bundleFilename = bundleName + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
         File buildDir = new File(testProjectDir, "build");
         File buildGatewayDir = validateBuildDirExceptGW7File(bundleFilename, buildDir);
 
         //Environment bundle name format : <bundleName>-<version>-[<configName>]env.install.bundle
-        String envBundleFilename = bundleName + projectVersion + "-config" + ENV_INSTALL_BUNDLE_NAME_SUFFIX;
+        String envBundleFilename = bundleName + projectVersion + "-config" + ENV_INSTALL_BUNDLE_SUFFIX;
         File builtBundleFile = new File(new File(buildGatewayDir, "bundle"), envBundleFilename);
     }
 
@@ -342,11 +345,12 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":build-environment-bundle")).getOutcome());
 
         File buildDir = new File(testProjectDir, "build");
-        File buildGatewayDir = validateBuildDirExceptGW7File(bundleName, buildDir);
+        String bundleFilename = bundleName + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
+        File buildGatewayDir = validateBuildDirExceptGW7File(bundleFilename, buildDir);
 
-        File builtDeleteEnvBundleFile = new File(new File(buildGatewayDir, "bundle"), bundleName + projectVersion + "-configenv.install.delete.bundle");
+        String envDeleteBundleFilename = bundleName + projectVersion + "-config" + ENV_DELETE_BUNDLE_SUFFIX;
+        File builtDeleteEnvBundleFile = new File(new File(buildGatewayDir, "bundle"), envDeleteBundleFilename);
         assertTrue(builtDeleteEnvBundleFile.isFile());
-
     }
 
     @Test
@@ -374,17 +378,21 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":build-bundle")).getOutcome());
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":build-environment-bundle")).getOutcome());
 
+        String bundleFilename = bundleName + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
+        String deleteBundleFilename = bundleName + projectVersion + "-policy" + DELETE_BUNDLE_EXTENSION;
         File buildDir = new File(testProjectDir, "build");
-        File buildGatewayDir = validateBuildDirExceptGW7File(bundleName, buildDir);
+        File buildGatewayDir = validateBuildDirExceptGW7File(bundleFilename, buildDir);
 
         //Environment bundle name format : <bundleName>-<version>.(<configName>.)environment.bundle
-        File builtBundleFile = new File(new File(buildGatewayDir, "bundle"), bundleName + projectVersion + "-config" + ENV_INSTALL_BUNDLE_NAME_SUFFIX);
+        String envBundleFilename = bundleName + projectVersion + "-config" + ENV_INSTALL_BUNDLE_SUFFIX;
+        File builtBundleFile = new File(new File(buildGatewayDir, "bundle"), envBundleFilename);
         assertTrue(builtBundleFile.isFile());
 
-        File builtDeleteEnvBundleFile = new File(new File(buildGatewayDir, "bundle"), bundleName + projectVersion + "-config" + ENV_DELETE_BUNDLE_NAME_SUFFIX);
+        String envDeleteBundleFilename = bundleName + projectVersion + "-config" + ENV_DELETE_BUNDLE_SUFFIX;
+        File builtDeleteEnvBundleFile = new File(new File(buildGatewayDir, "bundle"), envDeleteBundleFilename);
         assertTrue(builtDeleteEnvBundleFile.isFile());
 
-        File builtDeleteBundleFile = new File(new File(buildGatewayDir, "bundle"), bundleName + projectVersion + ".delete.bundle");
+        File builtDeleteBundleFile = new File(new File(buildGatewayDir, "bundle"), deleteBundleFilename);
         assertTrue(builtDeleteBundleFile.isFile());
     }
 
@@ -501,7 +509,7 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":build-full-bundle")).getOutcome());
 
         File buildDir = new File(testProjectDir, "build");
-        String bundleFilename = bundleName + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String bundleFilename = bundleName + projectVersion + POLICY_INSTALL_BUNDLE_SUFFIX;
         File buildGatewayDir = validateBuildDirExceptGW7File(bundleFilename, buildDir);
 
         //Deployment bundle name format : <bundleName>-<version>.bundle

--- a/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
+++ b/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
@@ -70,7 +70,7 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":build")).getOutcome());
 
         File buildDir = new File(testProjectDir, "build");
-        String bundleFileName = projectFolder + projectVersion + "-full" + INSTALL_BUNDLE_EXTENSION;
+        String bundleFileName = projectFolder + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
         validateBuildDir(projectFolder, bundleFileName, buildDir);
     }
 
@@ -93,7 +93,7 @@ class CAGatewayDeveloperTest {
 
         File buildGatewayDir = new File(testProjectDir, "dist");
         assertTrue(buildGatewayDir.isDirectory());
-        String bundleFileName = projectFolder + projectVersion + "-full" + INSTALL_BUNDLE_EXTENSION;
+        String bundleFileName = projectFolder + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
         File builtBundleFile = new File(buildGatewayDir, bundleFileName);
         assertTrue(builtBundleFile.isFile());
     }
@@ -141,10 +141,14 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":project-a:build")).getOutcome());
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":project-b:build")).getOutcome());
 
-        validateBuildDir("project-a", "", new File(new File(testProjectDir, "project-a"), "build"));
-        validateBuildDir("project-b" , "", new File(new File(testProjectDir, "project-b"), "build"));
-        validateBuildDir("project-c" , "", new File(new File(testProjectDir, "project-c"), "build"));
-        validateBuildDir("project-d" , "", new File(new File(testProjectDir, "project-d"), "build"));
+        String projectAFilename = "project-a" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String projectBFilename = "project-b" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String projectCFilename = "project-c" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String projectDFilename = "project-d" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        validateBuildDir("project-a", projectAFilename, new File(new File(testProjectDir, "project-a"), "build"));
+        validateBuildDir("project-b" , projectBFilename, new File(new File(testProjectDir, "project-b"), "build"));
+        validateBuildDir("project-c" , projectCFilename, new File(new File(testProjectDir, "project-c"), "build"));
+        validateBuildDir("project-d" , projectDFilename, new File(new File(testProjectDir, "project-d"), "build"));
 
         File projectC_GW7 = new File(new File(new File(new File(testProjectDir, "project-c"), "build"), "gateway"), "project-c" + projectVersion + ".gw7");
 
@@ -154,10 +158,10 @@ class CAGatewayDeveloperTest {
         while ((entry = tarArchiveInputStream.getNextTarEntry()) != null) {
             entries.add(entry.getName());
         }
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_1_project-b-1.2.3-SNAPSHOT.req.bundle"));
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_2_project-d-1.2.3-SNAPSHOT.req.bundle"));
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_3_project-a-1.2.3-SNAPSHOT.req.bundle"));
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_4_project-c-1.2.3-SNAPSHOT.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_1_project-b-1.2.3-SNAPSHOT-policy.install.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_2_project-d-1.2.3-SNAPSHOT-policy.install.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_3_project-a-1.2.3-SNAPSHOT-policy.install.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_4_project-c-1.2.3-SNAPSHOT-policy.install.req.bundle"));
         tarArchiveInputStream.close();
     }
 
@@ -179,7 +183,7 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":build")).getOutcome());
 
         File buildDir = new File(testProjectDir, "build");
-        String bundleFileName = projectFolder + projectVersion + "-full" + INSTALL_BUNDLE_EXTENSION;
+        String bundleFileName = projectFolder + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
         File gw7 = validateBuildDir(projectFolder, bundleFileName, buildDir);
 
         TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(gw7)));
@@ -189,7 +193,8 @@ class CAGatewayDeveloperTest {
             entries.add(entry.getName());
         }
         assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_1_my-bundle-1.0.00.req.bundle"));
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_2_example-project-with-assertions-dependencies-1.2.3-SNAPSHOT.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_2_example-project-with-assertions" +
+                "-dependencies-1.2.3-SNAPSHOT-policy.install.req.bundle"));
         assertTrue(entries.contains("opt/SecureSpan/Gateway/runtime/modules/lib/Test-1.0.0.jar"));
         assertTrue(entries.contains("opt/SecureSpan/Gateway/runtime/modules/assertions/Test-2.0.0.aar"));
     }
@@ -212,9 +217,12 @@ class CAGatewayDeveloperTest {
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":project-a:build")).getOutcome());
         assertEquals(TaskOutcome.SUCCESS, Objects.requireNonNull(result.task(":project-b:build")).getOutcome());
 
-        validateBuildDir("project-a" , "", new File(new File(testProjectDir, "project-a"), "build"));
-        validateBuildDir("project-b" , "", new File(new File(testProjectDir, "project-b"), "build"));
-        validateBuildDir("project-c" , "", new File(new File(testProjectDir, "project-c"), "build"));
+        String projectAFilename = "project-a" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String projectBFilename = "project-b" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        String projectCFilename = "project-c" + projectVersion + "-policy" + INSTALL_BUNDLE_EXTENSION;
+        validateBuildDir("project-a" , projectAFilename, new File(new File(testProjectDir, "project-a"), "build"));
+        validateBuildDir("project-b" , projectBFilename, new File(new File(testProjectDir, "project-b"), "build"));
+        validateBuildDir("project-c" , projectCFilename, new File(new File(testProjectDir, "project-c"), "build"));
 
         File projectC_GW7 = new File(new File(new File(new File(testProjectDir, "project-c"), "build"), "gateway"), "project-c" + projectVersion + ".gw7");
 
@@ -224,9 +232,9 @@ class CAGatewayDeveloperTest {
         while ((entry = tarArchiveInputStream.getNextTarEntry()) != null) {
             entries.add(entry.getName());
         }
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_1_project-a-1.2.3-SNAPSHOT.req.bundle"));
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_2_project-b-1.2.3-SNAPSHOT.req.bundle"));
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_3_project-c-1.2.3-SNAPSHOT.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_1_project-a-1.2.3-SNAPSHOT-policy.install.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_2_project-b-1.2.3-SNAPSHOT-policy.install.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_3_project-c-1.2.3-SNAPSHOT-policy.install.req.bundle"));
         assertTrue(entries.contains("opt/SecureSpan/Gateway/runtime/modules/lib/Test-1.0.0.jar"));
         tarArchiveInputStream.close();
     }

--- a/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
+++ b/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
@@ -398,40 +398,6 @@ class CAGatewayDeveloperTest {
 
     @Test
     @ExtendWith(TemporaryFolderExtension.class)
-    void testExampleProjectGeneratingEnvironmentWithMissingValues(TemporaryFolder temporaryFolder) throws IOException, URISyntaxException {
-        String projectFolder = "example-project-generating-environment";
-        File testProjectDir = new File(temporaryFolder.getRoot(), projectFolder);
-        FileUtils.copyDirectory(new File(Objects.requireNonNull(getClass().getClassLoader().getResource(projectFolder)).toURI()), testProjectDir);
-
-        assertThrows(UnexpectedBuildFailure.class, () -> GradleRunner.create()
-                .withProjectDir(testProjectDir)
-                .withArguments("build-environment-bundle", "--stacktrace", "-PjarDir=" + System.getProperty("user.dir") + "/build/test-mvn-repo",
-                        "-DconfigFolder=src/main/gateway/config_missing",
-                        "-DconfigName=config")
-                .withPluginClasspath()
-                .withDebug(true)
-                .build());
-    }
-
-    @Test
-    @ExtendWith(TemporaryFolderExtension.class)
-    void testExampleProjectGeneratingEnvironmentWithInvalidFilePath(TemporaryFolder temporaryFolder) throws IOException, URISyntaxException {
-        String projectFolder = "example-project-generating-environment";
-        File testProjectDir = new File(temporaryFolder.getRoot(), projectFolder);
-        FileUtils.copyDirectory(new File(Objects.requireNonNull(getClass().getClassLoader().getResource(projectFolder)).toURI()), testProjectDir);
-
-        assertThrows(UnexpectedBuildFailure.class, () -> GradleRunner.create()
-                .withProjectDir(testProjectDir)
-                .withArguments("build-environment-bundle", "--stacktrace", "-PjarDir=" + System.getProperty("user.dir") + "/build/test-mvn-repo",
-                        "-DconfigFolder=src/main/gateway/config_invalid",
-                        "-DconfigName=config")
-                .withPluginClasspath()
-                .withDebug(true)
-                .build());
-    }
-
-    @Test
-    @ExtendWith(TemporaryFolderExtension.class)
     void testExampleProjectGeneratingEnvironmentJsonWithoutExpectedEntity(TemporaryFolder temporaryFolder) throws IOException, URISyntaxException {
         String projectFolder = "example-project-generating-environment";
         File testProjectDir = new File(temporaryFolder.getRoot(), projectFolder);

--- a/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
+++ b/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
@@ -268,7 +268,7 @@ class CAGatewayDeveloperTest {
         File buildDir = new File(testProjectDir, "build");
         File buildGatewayDir = validateBuildDirExceptGW7File(bundleFilename, buildDir);
 
-        //Environment bundle name format : <bundleName>-<version>.(<configName>)env.install.bundle
+        //Environment bundle name format : <bundleName>-<version>-[<configName>]env.install.bundle
         String envBundleFilename = bundleName + projectVersion + "-configenv" + INSTALL_BUNDLE_EXTENSION;
         File builtBundleFile = new File(new File(buildGatewayDir, "bundle"), envBundleFilename);
         assertTrue(builtBundleFile.isFile());


### PR DESCRIPTION
## Description
Applying changes in naming convention and some metadata related change.

## Proposed Changes
- Introducing a new field `metaVersion: 1.0` to keep track of the bundle metadata version.
- Revisiting the bundle's type literals (service|encass|policy|any --> SERVICE|ENCAPSULATED_ASSERTION|POLICY|ALL)
- Revisiting the bundle artifact naming conventions
- Metadata Id is now taken from `id` in `@bundle` annotation or generates random