### PR TITLE
Revisiting the unique naming convention for the entities included in the self-contained bundle

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -202,7 +202,8 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     public String getType() {
         return EntityTypes.ENCAPSULATED_ASSERTION_TYPE;
     }
-    
+
+    @JsonIgnore
     @Override
     public String getShortenedType() {
         return "encass";

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -202,10 +202,4 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     public String getType() {
         return EntityTypes.ENCAPSULATED_ASSERTION_TYPE;
     }
-
-    @JsonIgnore
-    @Override
-    public String getShortenedType() {
-        return "encass";
-    }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
@@ -267,12 +267,6 @@ public class Policy extends Folderable implements AnnotableEntity {
 
     @JsonIgnore
     @Override
-    public String getShortenedType() {
-        return "policy";
-    }
-
-    @JsonIgnore
-    @Override
     public Metadata getMetadata() {
         return new Metadata() {
             @Override

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
@@ -265,6 +265,7 @@ public class Policy extends Folderable implements AnnotableEntity {
         return EntityTypes.POLICY_TYPE;
     }
 
+    @JsonIgnore
     @Override
     public String getShortenedType() {
         return "policy";

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Service.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Service.java
@@ -227,11 +227,6 @@ public class Service extends Folderable implements AnnotableEntity {
     }
 
     @Override
-    public String getShortenedType() {
-        return "service";
-    }
-
-    @Override
     public void postLoad(String entityKey, Bundle bundle, File rootFolder, IdGenerator idGenerator) {
         setGuid(idGenerator.generateGuid());
         setId(idGenerator.generate());

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotableEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotableEntity.java
@@ -32,15 +32,6 @@ public interface AnnotableEntity {
     String getType();
 
     /**
-     * Returns short name of Entity Type. For example, for ENCAPSUPATED_ASSERTION it returns "encass", for POLICY
-     * it returns "policy", and for SERVICE it returns "service"
-     *
-     * @return Shortened type
-     */
-    @JsonIgnore
-    String getShortenedType();
-
-    /**
 
      * This method returns all the Annotation applied to the entity.
      *

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedBundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedBundle.java
@@ -10,6 +10,7 @@ public class AnnotatedBundle extends Bundle {
     private Bundle fullBundle;
     private AnnotatedEntity<? extends GatewayEntity> annotatedEntity;
     private ProjectInfo projectInfo;
+    private String uniqueNameSeparator = "#";   // This can be different for environment entities.
 
     public AnnotatedBundle(Bundle fullBundle, AnnotatedEntity<? extends GatewayEntity> annotatedEntity,
                            ProjectInfo projectInfo) {
@@ -43,8 +44,7 @@ public class AnnotatedBundle extends Bundle {
     }
 
     public String getUniquePrefix() {
-        AnnotableEntity annotableEntity = (AnnotableEntity) annotatedEntity.getEntity();
-        return projectInfo.getName() + "-" + annotableEntity.getShortenedType() + "-" + PathUtils.extractName(annotatedEntity.getEntityName()) + "-";
+        return projectInfo.getName() + uniqueNameSeparator + PathUtils.extractName(annotatedEntity.getEntityName()) + uniqueNameSeparator;
     }
 
     public String getUniqueSuffix() {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -146,7 +146,7 @@ public class EncassEntityBuilder implements EntityBuilder {
                     }
                 }
             } else {
-                encassName = annotatedBundle.getUniquePrefix() + name + annotatedBundle.getUniqueSuffix();
+                encassName = annotatedBundle.getUniquePrefix() + name;
                 //guid and id are regenerated in policy entity builder if this encass is referred by policy and it runs before this builder
                 //no need to regenerate id and guid
             }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -153,7 +153,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
             if (policy.isReusable() || isAnnotatedEntity(policy, annotatedEntity)) {
                 policyName = policy.getName();
             } else {
-                policyName = annotatedBundle.getUniquePrefix() + policy.getName() + annotatedBundle.getUniqueSuffix();
+                policyName = annotatedBundle.getUniquePrefix() + policy.getName();
             }
         } else {
             policyName = policy.getName();
@@ -385,7 +385,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
                 encassGuid = idGenerator.generateGuid();
                 encass.setGuid(encassGuid);
                 encass.setId(idGenerator.generate());
-                encassName = annotatedBundle.getUniquePrefix() + encassName + annotatedBundle.getUniqueSuffix();
+                encassName = annotatedBundle.getUniquePrefix() + encassName;
             }
         }
         Element encapsulatedAssertionConfigNameElement = createElementWithAttribute(
@@ -517,7 +517,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
         final boolean isRedeployableBundle = annotatedEntity != null && annotatedEntity.isRedeployable();
         if (annotatedBundle != null) {
             if (!policy.isReusable() && !isAnnotatedEntity(policy, annotatedEntity)) {
-                policyName = annotatedBundle.getUniquePrefix() + policyName + annotatedBundle.getUniqueSuffix();
+                policyName = annotatedBundle.getUniquePrefix() + policyName;
                 policyNameWithPath = PathUtils.extractPath(policy.getPath()) + policyName;
             }
         }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
@@ -123,8 +123,8 @@ class BundleEntityBuilderTest {
         entityBuilders.add(policyBuilder);
         entityBuilders.add(encassBuilder);
 
-        buildAndValidateAnnotatedBundle(bundle, entityBuilders, "my-bundle-encass-TestEncass-" + TEST_ENCASS_POLICY + "-1.0", NEW_OR_UPDATE, TEST_ENCASS, NEW_OR_EXISTING,
-                TEST_DEP_ENCASS_POLICY, NEW_OR_EXISTING, "my-bundle-encass-TestEncass-" + TEST_DEP_ENCASS + "-1.0", NEW_OR_UPDATE);
+        buildAndValidateAnnotatedBundle(bundle, entityBuilders, "my-bundle#TestEncass#" + TEST_ENCASS_POLICY , NEW_OR_UPDATE, TEST_ENCASS, NEW_OR_EXISTING,
+                TEST_DEP_ENCASS_POLICY, NEW_OR_EXISTING, "my-bundle#TestEncass#" + TEST_DEP_ENCASS , NEW_OR_UPDATE);
     }
 
     @Test
@@ -175,7 +175,7 @@ class BundleEntityBuilderTest {
         entityBuilders.add(policyBuilder);
         entityBuilders.add(encassBuilder);
 
-        buildAndValidateAnnotatedBundle(bundle, entityBuilders, "my-bundle-encass-TestEncass-" + TEST_ENCASS_POLICY + "-1.0", NEW_OR_UPDATE, TEST_ENCASS, NEW_OR_UPDATE,
+        buildAndValidateAnnotatedBundle(bundle, entityBuilders, "my-bundle#TestEncass#" + TEST_ENCASS_POLICY , NEW_OR_UPDATE, TEST_ENCASS, NEW_OR_UPDATE,
                 TEST_DEP_ENCASS_POLICY, NEW_OR_UPDATE, TEST_DEP_ENCASS, NEW_OR_UPDATE);
 
     }
@@ -277,7 +277,7 @@ class BundleEntityBuilderTest {
         assertNotNull(itemList);
         assertEquals(expectedElementCountBundle, itemList.size());
         final Element item1 = itemList.get(1);
-        assertEquals("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_ENCASS_POLICY + "-1.0",
+        assertEquals("my-bundle#" + TEST_ENCASS + "#" + TEST_ENCASS_POLICY ,
                 getSingleChildElementTextContent(item1, NAME));
         assertEquals(EntityTypes.POLICY_TYPE, getSingleChildElementTextContent(item1, TYPE));
         assertNotNull(getSingleChildElement(item1, RESOURCE));
@@ -328,12 +328,12 @@ class BundleEntityBuilderTest {
         assertNotNull(itemList);
         assertEquals(expectedElementCountBundle, itemList.size());
         final Element item1 = itemList.get(2);
-        assertEquals("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_POLICY_FRAGMENT + "-1.0",
+        assertEquals("my-bundle#" + TEST_ENCASS + "#" + TEST_POLICY_FRAGMENT ,
                 getSingleChildElementTextContent(item1, NAME));
         assertEquals(EntityTypes.POLICY_TYPE, getSingleChildElementTextContent(item1, TYPE));
         assertNotNull(getSingleChildElement(item1, RESOURCE));
         final Element item2 = itemList.get(1);
-        assertEquals("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_ENCASS_POLICY + "-1.0",
+        assertEquals("my-bundle#" + TEST_ENCASS + "#" + TEST_ENCASS_POLICY ,
                 getSingleChildElementTextContent(item2, NAME));
         assertEquals(EntityTypes.POLICY_TYPE, getSingleChildElementTextContent(item2, TYPE));
         assertNotNull(getSingleChildElement(item2, RESOURCE));
@@ -351,14 +351,14 @@ class BundleEntityBuilderTest {
         final Element mapping1 = mappingItemList.get(2);
         final Element mapping1Properties = getSingleChildElement(mapping1, PROPERTIES);
         Set<String> propertyValues = getChildElementsTextContents(mapping1Properties, PROPERTY);
-        assertTrue(propertyValues.contains("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_POLICY_FRAGMENT + "-1.0"));
+        assertTrue(propertyValues.contains("my-bundle#" + TEST_ENCASS + "#" + TEST_POLICY_FRAGMENT ));
         assertEquals(MappingActions.DELETE, mapping1.getAttribute("action"));
         assertEquals(EntityTypes.POLICY_TYPE, mapping1.getAttribute("type"));
 
         final Element mapping2 = mappingItemList.get(1);
         final Element mapping2Properties = getSingleChildElement(mapping2, PROPERTIES);
         propertyValues = getChildElementsTextContents(mapping2Properties, PROPERTY);
-        assertTrue(propertyValues.contains("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_ENCASS_POLICY + "-1.0"));
+        assertTrue(propertyValues.contains("my-bundle#" + TEST_ENCASS + "#" + TEST_ENCASS_POLICY ));
         assertEquals(MappingActions.DELETE, mapping2.getAttribute("action"));
         assertEquals(EntityTypes.POLICY_TYPE, mapping2.getAttribute("type"));
 
@@ -398,12 +398,12 @@ class BundleEntityBuilderTest {
         assertNotNull(itemList);
         assertEquals(expectedElementCountBundle, itemList.size());
         final Element item1 = itemList.get(2);
-        assertEquals("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_POLICY_FRAGMENT + "-1.0",
+        assertEquals("my-bundle#" + TEST_ENCASS + "#" + TEST_POLICY_FRAGMENT,
                 getSingleChildElementTextContent(item1, NAME));
         assertEquals(EntityTypes.POLICY_TYPE, getSingleChildElementTextContent(item1, TYPE));
         assertNotNull(getSingleChildElement(item1, RESOURCE));
         final Element item2 = itemList.get(1);
-        assertEquals("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_ENCASS_POLICY + "-1.0",
+        assertEquals("my-bundle#" + TEST_ENCASS + "#" + TEST_ENCASS_POLICY,
                 getSingleChildElementTextContent(item2, NAME));
         assertEquals(EntityTypes.POLICY_TYPE, getSingleChildElementTextContent(item2, TYPE));
         assertNotNull(getSingleChildElement(item2, RESOURCE));
@@ -421,14 +421,14 @@ class BundleEntityBuilderTest {
         final Element mapping1 = mappingItemList.get(2);
         final Element mapping1Properties = getSingleChildElement(mapping1, PROPERTIES);
         Set<String> propertyValues = getChildElementsTextContents(mapping1Properties, PROPERTY);
-        assertTrue(propertyValues.contains("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_POLICY_FRAGMENT + "-1.0"));
+        assertTrue(propertyValues.contains("my-bundle#" + TEST_ENCASS + "#" + TEST_POLICY_FRAGMENT ));
         assertEquals(MappingActions.DELETE, mapping1.getAttribute("action"));
         assertEquals(EntityTypes.POLICY_TYPE, mapping1.getAttribute("type"));
 
         final Element mapping2 = mappingItemList.get(1);
         final Element mapping2Properties = getSingleChildElement(mapping2, PROPERTIES);
         propertyValues = getChildElementsTextContents(mapping2Properties, PROPERTY);
-        assertTrue(propertyValues.contains("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_ENCASS_POLICY + "-1.0"));
+        assertTrue(propertyValues.contains("my-bundle#" + TEST_ENCASS + "#" + TEST_ENCASS_POLICY ));
         assertEquals(MappingActions.DELETE, mapping2.getAttribute("action"));
         assertEquals(EntityTypes.POLICY_TYPE, mapping2.getAttribute("type"));
 
@@ -469,7 +469,7 @@ class BundleEntityBuilderTest {
         assertEquals(expectedElementCountBundle, itemList.size());
 
         final Element item2 = itemList.get(1);
-        assertEquals("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_ENCASS_POLICY + "-1.0",
+        assertEquals("my-bundle#" + TEST_ENCASS + "#" + TEST_ENCASS_POLICY ,
                 getSingleChildElementTextContent(item2, NAME));
         assertEquals(EntityTypes.POLICY_TYPE, getSingleChildElementTextContent(item2, TYPE));
         assertNotNull(getSingleChildElement(item2, RESOURCE));
@@ -489,7 +489,7 @@ class BundleEntityBuilderTest {
         final Element mapping2 = mappingItemList.get(1);
         final Element mapping2Properties = getSingleChildElement(mapping2, PROPERTIES);
         propertyValues = getChildElementsTextContents(mapping2Properties, PROPERTY);
-        assertTrue(propertyValues.contains("my-bundle-encass-" + TEST_ENCASS + "-" + TEST_ENCASS_POLICY + "-1.0"));
+        assertTrue(propertyValues.contains("my-bundle#" + TEST_ENCASS + "#" + TEST_ENCASS_POLICY ));
         assertEquals(MappingActions.DELETE, mapping2.getAttribute("action"));
         assertEquals(EntityTypes.POLICY_TYPE, mapping2.getAttribute("type"));
 


### PR DESCRIPTION
Fixes #

- Ignoring the **shortenedType** property
- Unique naming changed to {project-name}#[bundle-name}#{entity-name}

Noticeble changes: 
- used # as separator. # is very unlikely character used in naming the policies or encasses. Hence, chosen to identify the parts.
- excluded <version>

