### PR TITLE
DE461108 : Environment ID issue after import

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GatewayEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GatewayEntity.java
@@ -67,7 +67,6 @@ public class GatewayEntity {
         //
     }
 
-    @JsonIgnore
     public Metadata getMetadata() {
         return null;
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GatewayEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GatewayEntity.java
@@ -67,6 +67,7 @@ public class GatewayEntity {
         //
     }
 
+    @JsonIgnore
     public Metadata getMetadata() {
         return null;
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/TrustedCert.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/TrustedCert.java
@@ -38,7 +38,7 @@ import static java.lang.Boolean.parseBoolean;
 import static java.util.Collections.emptyMap;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
-@JsonInclude
+@JsonInclude(Include.NON_NULL)
 @Named("TRUSTED_CERT")
 @ConfigurationFile(name = "trusted-certs", type = JSON_YAML)
 @EnvironmentType("CERTIFICATE")
@@ -99,7 +99,6 @@ public class TrustedCert extends GatewayEntity implements AnnotableEntity {
         this.certificateData = certificateData;
     }
 
-    @JsonIgnore
     public CertificateData getCertificateData() {
         return certificateData;
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/TrustedCert.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/TrustedCert.java
@@ -245,11 +245,6 @@ public class TrustedCert extends GatewayEntity implements AnnotableEntity {
     }
 
     @Override
-    public String getShortenedType() {
-        return "trusted_cert";
-    }
-
-    @Override
     public void postLoad(String entityKey, Bundle bundle, @Nullable File rootFolder, IdGenerator idGenerator) {
         super.postLoad(entityKey, bundle, rootFolder, idGenerator);
         setName(entityKey);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -50,7 +50,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 public class PolicyEntityBuilder implements EntityBuilder {
     private static final Logger LOGGER = Logger.getLogger(PolicyEntityBuilder.class.getName());
 
-    private static final String STRING_VALUE = "stringValue";
+    public static final String STRING_VALUE = "stringValue";
     private static final String GOID_VALUE = "goidValue";
     private static final String GOID_ARRAY_VALUE = "goidArrayValue";
     static final String BOOLEAN_VALUE = "booleanValue";
@@ -513,11 +513,11 @@ public class PolicyEntityBuilder implements EntityBuilder {
     }
 
     private static void prepareRoutingAssertionCertificateIds(Document policyDocument, Bundle bundle, Element assertionElement) {
-        final Element trustedCertNameElement = getSingleChildElement(assertionElement, TLS_TRUSTED_CERT_NAME, true);
+        final Element trustedCertNameElement = getSingleChildElement(assertionElement, TLS_TRUSTED_CERT_NAMES, true);
         if (trustedCertNameElement != null && trustedCertNameElement.getChildNodes().getLength() > 0) {
             Element trustedCertGoidElement = createElementWithAttribute(
                     policyDocument,
-                    TLS_TRUSTED_CERT_ID,
+                    TLS_TRUSTED_CERT_IDS,
                     GOID_ARRAY_VALUE,
                     "included"
             );

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -526,15 +526,16 @@ public class PolicyEntityBuilder implements EntityBuilder {
             for (int i = 0; i < trustedCertNamesList.getLength(); i++) {
                 final String trustedCertName = trustedCertNamesList.item(i).getAttributes().getNamedItem(STRING_VALUE).getTextContent();
                 final TrustedCert trustedCert = bundle.getTrustedCerts().get(trustedCertName);
-                if (trustedCert != null && trustedCert.getAnnotatedEntity() != null && trustedCert.getAnnotatedEntity().getId() != null) {
-                    Element trustedCertGoidItem = createElementWithAttribute(
-                            policyDocument,
-                            PolicyXMLElements.ITEM,
-                            GOID_VALUE,
-                            trustedCert.getAnnotatedEntity().getId()
-                    );
-                    trustedCertGoidElement.appendChild(trustedCertGoidItem);
-                }
+                final String trustedCertId = trustedCert != null && trustedCert.getAnnotatedEntity() != null && trustedCert.getAnnotatedEntity().getId() != null ?
+                        trustedCert.getAnnotatedEntity().getId() : idGenerator.generate();
+
+                Element trustedCertGoidItem = createElementWithAttribute(
+                        policyDocument,
+                        PolicyXMLElements.ITEM,
+                        GOID_VALUE,
+                        trustedCertId
+                );
+                trustedCertGoidElement.appendChild(trustedCertGoidItem);
             }
         }
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -510,7 +510,8 @@ public class PolicyEntityBuilder implements EntityBuilder {
         }
     }
 
-    private static void prepareRoutingAssertionCertificateIds(Document policyDocument, Bundle bundle, Element assertionElement) {
+    @VisibleForTesting
+    void prepareRoutingAssertionCertificateIds(Document policyDocument, Bundle bundle, Element assertionElement) {
         final Element trustedCertNameElement = getSingleChildElement(assertionElement, TLS_TRUSTED_CERT_NAMES, true);
         if (trustedCertNameElement != null && trustedCertNameElement.getChildNodes().getLength() > 0) {
             Element trustedCertGoidElement = createElementWithAttribute(

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -50,9 +50,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 public class PolicyEntityBuilder implements EntityBuilder {
     private static final Logger LOGGER = Logger.getLogger(PolicyEntityBuilder.class.getName());
 
-    public static final String STRING_VALUE = "stringValue";
-    private static final String GOID_VALUE = "goidValue";
-    private static final String GOID_ARRAY_VALUE = "goidArrayValue";
+    static final String STRING_VALUE = "stringValue";
     static final String BOOLEAN_VALUE = "booleanValue";
     static final String POLICY_PATH = "policyPath";
     static final String ENCASS_NAME = "encassName";

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/TrustedCertEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/TrustedCertEntityBuilder.java
@@ -72,7 +72,9 @@ public class TrustedCertEntityBuilder implements EntityBuilder {
             case DEPLOYMENT:
                 return entities.entrySet().stream()
                         .map(
-                                trustedCertEntry -> EntityBuilderHelper.getEntityWithOnlyMapping(TRUSTED_CERT_TYPE, trustedCertEntry.getKey(), idGenerator.generate())
+                                trustedCertEntry -> EntityBuilderHelper.getEntityWithOnlyMapping(TRUSTED_CERT_TYPE, trustedCertEntry.getKey(),
+                                        ((TrustedCert)trustedCertEntry.getValue()).getAnnotatedEntity() != null && ((TrustedCert)trustedCertEntry.getValue()).getAnnotatedEntity().getId() != null ?
+                                                ((TrustedCert)trustedCertEntry.getValue()).getAnnotatedEntity().getId() : idGenerator.generate())
                         ).collect(Collectors.toList());
             case ENVIRONMENT:
                 return entities.entrySet().stream().map(trustedCertEntry ->
@@ -84,7 +86,8 @@ public class TrustedCertEntityBuilder implements EntityBuilder {
     }
 
     private Entity buildTrustedCertEntity(String name, TrustedCert trustedCert, Map<String, SupplierWithIO<InputStream>> certificateFiles, Document document) {
-        final String id = idGenerator.generate();
+        final String id = trustedCert.getAnnotatedEntity() != null && trustedCert.getAnnotatedEntity().getId() != null ?
+                trustedCert.getAnnotatedEntity().getId(): idGenerator.generate();
         trustedCert.setId(id);
         final Element trustedCertElem = createElementWithAttributesAndChildren(
                 document,

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/TrustedCertEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/TrustedCertEntityBuilder.java
@@ -72,9 +72,7 @@ public class TrustedCertEntityBuilder implements EntityBuilder {
             case DEPLOYMENT:
                 return entities.entrySet().stream()
                         .map(
-                                trustedCertEntry -> EntityBuilderHelper.getEntityWithOnlyMapping(TRUSTED_CERT_TYPE, trustedCertEntry.getKey(),
-                                        ((TrustedCert)trustedCertEntry.getValue()).getAnnotatedEntity() != null && ((TrustedCert)trustedCertEntry.getValue()).getAnnotatedEntity().getId() != null ?
-                                                ((TrustedCert)trustedCertEntry.getValue()).getAnnotatedEntity().getId() : idGenerator.generate())
+                                trustedCertEntry -> EntityBuilderHelper.getEntityWithOnlyMapping(TRUSTED_CERT_TYPE, trustedCertEntry.getKey(), generateCertificateId((TrustedCert)trustedCertEntry.getValue()))
                         ).collect(Collectors.toList());
             case ENVIRONMENT:
                 return entities.entrySet().stream().map(trustedCertEntry ->
@@ -86,8 +84,7 @@ public class TrustedCertEntityBuilder implements EntityBuilder {
     }
 
     private Entity buildTrustedCertEntity(String name, TrustedCert trustedCert, Map<String, SupplierWithIO<InputStream>> certificateFiles, Document document) {
-        final String id = trustedCert.getAnnotatedEntity() != null && trustedCert.getAnnotatedEntity().getId() != null ?
-                trustedCert.getAnnotatedEntity().getId(): idGenerator.generate();
+        final String id = generateCertificateId(trustedCert);
         trustedCert.setId(id);
         final Element trustedCertElem = createElementWithAttributesAndChildren(
                 document,
@@ -99,6 +96,13 @@ public class TrustedCertEntityBuilder implements EntityBuilder {
         buildAndAppendPropertiesElement(trustedCert.createProperties(), document, trustedCertElem);
 
         return EntityBuilderHelper.getEntityWithNameMapping(TRUSTED_CERT_TYPE, name, id, trustedCertElem);
+    }
+
+    private String generateCertificateId(TrustedCert trustedCert) {
+        if (trustedCert != null && trustedCert.getAnnotatedEntity() != null && trustedCert.getAnnotatedEntity().getId() != null) {
+            return trustedCert.getAnnotatedEntity().getId();
+        }
+        return idGenerator.generate();
     }
 
     private Element buildCertData(String name, TrustedCert trustedCert, Map<String, SupplierWithIO<InputStream>> certificateFiles, Document document) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/TrustedCertLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/TrustedCertLoader.java
@@ -6,15 +6,19 @@
 
 package com.ca.apim.gateway.cagatewayconfig.bundle.loader;
 
+import com.ca.apim.gateway.cagatewayconfig.beans.Annotation;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.TrustedCert;
 import com.ca.apim.gateway.cagatewayconfig.beans.TrustedCert.CertificateData;
+import com.ca.apim.gateway.cagatewayconfig.util.entity.AnnotationConstants;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
 import java.math.BigInteger;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.mapPropertiesElements;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
@@ -33,6 +37,11 @@ public class TrustedCertLoader implements BundleEntityLoader {
         TrustedCert cert = new TrustedCert(properties, getCertData(trustedCertElem));
         cert.setId(trustedCertElem.getAttribute(ATTRIBUTE_ID));
         cert.setName(getSingleChildElementTextContent(trustedCertElem, NAME));
+        Set<Annotation> annotations = new HashSet<>();
+        Annotation bundleEntity = new Annotation(AnnotationConstants.ANNOTATION_TYPE_BUNDLE_ENTITY);
+        bundleEntity.setId(trustedCertElem.getAttribute(ATTRIBUTE_ID));
+        annotations.add(bundleEntity);
+        cert.setAnnotations(annotations);
         bundle.getTrustedCerts().put(name, cert);
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
@@ -33,6 +33,10 @@ public class PolicyXMLElements {
     public static final String JMS_ROUTING_ASSERTION = "L7p:JmsRoutingAssertion";
     public static final String JMS_ENDPOINT_OID = "L7p:EndpointOid";
     public static final String JMS_ENDPOINT_NAME = "L7p:EndpointName";
+    public static final String HTTP_ROUTING_ASSERTION  = "L7p:HttpRoutingAssertion";
+    public static final String TLS_TRUSTED_CERT_ID = "L7p:TlsTrustedCertGoids";
+    public static final String TLS_TRUSTED_CERT_NAME = "L7p:TlsTrustedCertNames";
+    public static final String ITEM = "L7p:item";
 
     private PolicyXMLElements() {
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
@@ -34,8 +34,8 @@ public class PolicyXMLElements {
     public static final String JMS_ENDPOINT_OID = "L7p:EndpointOid";
     public static final String JMS_ENDPOINT_NAME = "L7p:EndpointName";
     public static final String HTTP_ROUTING_ASSERTION  = "L7p:HttpRoutingAssertion";
-    public static final String TLS_TRUSTED_CERT_ID = "L7p:TlsTrustedCertGoids";
-    public static final String TLS_TRUSTED_CERT_NAME = "L7p:TlsTrustedCertNames";
+    public static final String TLS_TRUSTED_CERT_IDS = "L7p:TlsTrustedCertGoids";
+    public static final String TLS_TRUSTED_CERT_NAMES = "L7p:TlsTrustedCertNames";
     public static final String ITEM = "L7p:item";
 
     private PolicyXMLElements() {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
@@ -13,6 +13,7 @@ public class PolicyXMLElements {
 
     public static final String GOID_VALUE = "goidValue";
     public static final String STRING_VALUE = "stringValue";
+    public static final String GOID_ARRAY_VALUE = "goidArrayValue";
     public static final String INCLUDE = "L7p:Include";
     public static final String ENCAPSULATED = "L7p:Encapsulated";
     public static final String SET_VARIABLE = "L7p:SetVariable";

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilderTest.java
@@ -13,6 +13,7 @@ import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.AnnotationConstants;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties;
+import com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements;
 import com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
@@ -32,7 +33,9 @@ import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementName
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties.MAP_BY;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties.MAP_TO;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.STRING_VALUE;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PREFIX_ENV;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.VERIFY_HOSTNAME;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -45,7 +48,6 @@ class PolicyEntityBuilderTest {
     private Bundle bundle;
     private Document document;
     private final String TEST_ENCASS = "EncassName";
-
     @BeforeEach
     void beforeEach() {
         policy = new Policy();
@@ -871,6 +873,50 @@ class PolicyEntityBuilderTest {
         assertFalse(properties.isEmpty());
         assertEquals("internal-policy", properties.get(PropertyConstants.PROPERTY_TAG));
         assertNull(properties.get(PropertyConstants.PROPERTY_SUBTAG));
+    }
+
+    @Test
+    void testPrepareRoutingAssertionCertificateIds() {
+        PolicyEntityBuilder policyEntityBuilder = new PolicyEntityBuilder(DocumentTools.INSTANCE, new IdGenerator());
+        bundle.putAllTrustedCerts(ImmutableMap.of("fake-cert-1", createTrustedCertWithAnnotation(AnnotationConstants.ANNOTATION_TYPE_BUNDLE_ENTITY, "2cd473fe16d98cd6b9348ffb404517bc")));
+        bundle.putAllTrustedCerts(ImmutableMap.of("fake-cert-2", createTrustedCertWithAnnotation(AnnotationConstants.ANNOTATION_TYPE_BUNDLE_ENTITY, "28be78b936aa61bc75bd0df2089789cd")));
+
+        Element httpRoutingAssertionElement = createHttpRoutingAssertionWithCertNames(document);
+        policyEntityBuilder.prepareRoutingAssertionCertificateIds(document, bundle, httpRoutingAssertionElement);
+
+        final Element trustedCertIDElement = getSingleChildElement(httpRoutingAssertionElement, TLS_TRUSTED_CERT_IDS, true);
+        assertNotNull(trustedCertIDElement);
+        assertEquals(2, trustedCertIDElement.getChildNodes().getLength());
+        assertEquals("2cd473fe16d98cd6b9348ffb404517bc", trustedCertIDElement.getChildNodes().item(0).getAttributes().getNamedItem(GOID_VALUE).getTextContent());
+        assertEquals("28be78b936aa61bc75bd0df2089789cd", trustedCertIDElement.getChildNodes().item(1).getAttributes().getNamedItem(GOID_VALUE).getTextContent());
+    }
+
+    @NotNull
+    private Element createHttpRoutingAssertionWithCertNames(Document document) {
+        Element trustedCertNamesElement = createElementWithAttributesAndChildren(
+                document,
+                TLS_TRUSTED_CERT_NAMES,
+                org.testcontainers.shaded.com.google.common.collect.ImmutableMap.of("stringArrayValue", "included"),
+                createElementWithAttribute(document, PolicyXMLElements.ITEM, STRING_VALUE, "fake-cert-1"),
+                createElementWithAttribute(document, PolicyXMLElements.ITEM, STRING_VALUE, "fake-cert-2")
+        );
+
+        return createElementWithChildren(
+                document,
+                HTTP_ROUTING_ASSERTION,
+                trustedCertNamesElement
+        );
+    }
+
+    @NotNull
+    private TrustedCert createTrustedCertWithAnnotation(final String type, final String id) {
+        TrustedCert cert = new TrustedCert(ImmutableMap.of(VERIFY_HOSTNAME, true), null);
+        Set<Annotation> annotations = new HashSet<>();
+        Annotation annotation = new Annotation(type);
+        annotation.setId(id);
+        annotations.add(annotation);
+        cert.setAnnotations(annotations);
+        return cert;
     }
 
     private Element createIncludeAssertionElement(Document document, String policyPath) {

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/TrustedCertLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/TrustedCertLoaderTest.java
@@ -28,7 +28,7 @@ import java.nio.charset.Charset;
 
 import static com.ca.apim.gateway.cagatewayconfig.beans.EntityUtils.createEntityInfo;
 import static com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoaderUtils.createEntityLoader;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 @Extensions({ @ExtendWith(MockitoExtension.class), @ExtendWith(TemporaryFolderExtension.class) })
 public class TrustedCertLoaderTest {
@@ -108,7 +108,10 @@ public class TrustedCertLoaderTest {
                 "    revocationCheckingEnabled: true\n" +
                 "    trustedForSigningClientCerts: true\n" +
                 "    trustedForSigningServerCerts: true\n" +
-                "    trustedAsSamlIssuer: false";
+                "    trustedAsSamlIssuer: false\n" +
+                "    annotations:\n" +
+                "    - type: \"@bundle-entity\"\n" +
+                "      id: \"28be78b936aa61bc75bd0df2089789cd\"";
         final File configFolder = rootProjectDir.createDirectory("config");
         final File identityProvidersFile = new File(configFolder, "trusted-certs.yml");
         Files.touch(identityProvidersFile);
@@ -120,6 +123,8 @@ public class TrustedCertLoaderTest {
         assertEquals(1, bundle.getTrustedCerts().size());
         final TrustedCert trustedCert = bundle.getTrustedCerts().get("fake-cert");
         assertEquals(8, trustedCert.createProperties().size());
+        assertNotNull(trustedCert.getAnnotatedEntity().getId());
+        assertEquals("28be78b936aa61bc75bd0df2089789cd", trustedCert.getAnnotatedEntity().getId());
     }
 
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/HttpRoutingAssertionSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/HttpRoutingAssertionSimplifier.java
@@ -6,10 +6,8 @@
 
 package com.ca.apim.gateway.cagatewayexport.util.policy;
 
-import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import org.w3c.dom.Element;
 import javax.inject.Singleton;
-import java.util.logging.Logger;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElement;
@@ -20,16 +18,14 @@ import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSing
 @Singleton
 public class HttpRoutingAssertionSimplifier implements PolicyAssertionSimplifier {
 
-    private static final Logger LOGGER = Logger.getLogger(HttpRoutingAssertionSimplifier.class.getName());
-
     @Override
-    public void simplifyAssertionElement(PolicySimplifierContext context) throws DocumentParseException {
+    public void simplifyAssertionElement(PolicySimplifierContext context) {
         Element httpRoutingAssertionElement = context.getAssertionElement();
-        final Element httpRoutingCertGoidElement = getSingleChildElement(httpRoutingAssertionElement, TLS_TRUSTED_CERT_ID, true);
+        final Element httpRoutingCertGoidsElement = getSingleChildElement(httpRoutingAssertionElement, TLS_TRUSTED_CERT_IDS, true);
 
         // Remove trusted cert goid reference from routing assertion.
-        if (httpRoutingCertGoidElement != null) {
-            httpRoutingAssertionElement.removeChild(httpRoutingCertGoidElement);
+        if (httpRoutingCertGoidsElement != null) {
+            httpRoutingAssertionElement.removeChild(httpRoutingCertGoidsElement);
         }
     }
 

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/HttpRoutingAssertionSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/HttpRoutingAssertionSimplifier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018 CA. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+package com.ca.apim.gateway.cagatewayexport.util.policy;
+
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
+import org.w3c.dom.Element;
+import javax.inject.Singleton;
+import java.util.logging.Logger;
+
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElement;
+
+/**
+ * Simplifier for the HTTP Routing Assertion.
+ */
+@Singleton
+public class HttpRoutingAssertionSimplifier implements PolicyAssertionSimplifier {
+
+    private static final Logger LOGGER = Logger.getLogger(HttpRoutingAssertionSimplifier.class.getName());
+
+    @Override
+    public void simplifyAssertionElement(PolicySimplifierContext context) throws DocumentParseException {
+        Element httpRoutingAssertionElement = context.getAssertionElement();
+        final Element httpRoutingCertGoidElement = getSingleChildElement(httpRoutingAssertionElement, TLS_TRUSTED_CERT_ID, true);
+
+        // Remove trusted cert goid reference from routing assertion.
+        if (httpRoutingCertGoidElement != null) {
+            httpRoutingAssertionElement.removeChild(httpRoutingCertGoidElement);
+        }
+    }
+
+    @Override
+    public String getAssertionTagName() {
+        return HTTP_ROUTING_ASSERTION;
+    }
+}


### PR DESCRIPTION
Fixes #
Fixed the environment id issue for trusted cert in HttpRouting assertion

## Proposed Changes
Making use of @bundle-entity annotation to populate the ID of environment entity at the time of loading

## Links
Link Type   | Link
------      | ------
Rally Issue | DE461108
Func Spec   | 
## Checklist
- [x] Pull Request Created
- [ ] Code Review Completed
- [ ] Veracode scan results addressed
- [ ] SonarQube scan results addressed
- [ ] TPSR has been submitted (if applicable) 
- [X] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
- [ ] Func Spec has been updated as needed
- [ ] Rally Issue(s) are in an engineering completed state 
