### PR TITLE
DE461108 : Environment ID issue after import 

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/TrustedCert.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/TrustedCert.java
@@ -6,19 +6,30 @@
 
 package com.ca.apim.gateway.cagatewayconfig.beans;
 
+import com.ca.apim.gateway.cagatewayconfig.bundle.builder.AnnotableEntity;
+import com.ca.apim.gateway.cagatewayconfig.bundle.builder.AnnotatedEntity;
+import com.ca.apim.gateway.cagatewayconfig.bundle.builder.AnnotationDeserializer;
 import com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile;
 import com.ca.apim.gateway.cagatewayconfig.config.spec.EnvironmentType;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
+import com.ca.apim.gateway.cagatewayconfig.util.entity.AnnotationConstants;
+import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import org.jetbrains.annotations.Nullable;
+import sun.reflect.annotation.AnnotationType;
 
 import javax.inject.Named;
 import java.io.File;
 import java.math.BigInteger;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile.FileType.JSON_YAML;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.CertificateUtils.writeCertificateData;
@@ -31,7 +42,7 @@ import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 @Named("TRUSTED_CERT")
 @ConfigurationFile(name = "trusted-certs", type = JSON_YAML)
 @EnvironmentType("CERTIFICATE")
-public class TrustedCert extends GatewayEntity {
+public class TrustedCert extends GatewayEntity implements AnnotableEntity {
 
     private boolean verifyHostname;
     private boolean trustedForSsl;
@@ -42,6 +53,10 @@ public class TrustedCert extends GatewayEntity {
     private boolean trustedForSigningServerCerts;
     private boolean trustedAsSamlIssuer;
     private CertificateData certificateData;
+    @JsonDeserialize(using = AnnotationDeserializer.class)
+    private Set<Annotation> annotations;
+    @JsonIgnore
+    private AnnotatedEntity<? extends GatewayEntity> annotatedEntity;
 
     public TrustedCert() {}
 
@@ -160,6 +175,15 @@ public class TrustedCert extends GatewayEntity {
         return trustedAsSamlIssuer;
     }
 
+    @Override
+    public Set<Annotation> getAnnotations() {
+        return annotations;
+    }
+
+    public void setAnnotations(Set<Annotation> annotations) {
+        this.annotations = annotations;
+    }
+
     public static class Builder {
         private String id;
         private String name;
@@ -200,6 +224,24 @@ public class TrustedCert extends GatewayEntity {
 
         // remove the certificate data so it dont get written to the file
         this.certificateData = null;
+    }
+
+    @Override
+    public AnnotatedEntity getAnnotatedEntity() {
+        if (annotatedEntity == null && annotations != null) {
+            annotatedEntity = createAnnotatedEntity();
+        }
+        return annotatedEntity;
+    }
+
+    @VisibleForTesting
+    public void setAnnotatedEntity(AnnotatedEntity<Encass> annotatedEntity) {
+        this.annotatedEntity = annotatedEntity;
+    }
+
+    @Override
+    public String getType() {
+        return EntityTypes.TRUSTED_CERT_TYPE;
     }
 
     @Override

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/TrustedCertEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/TrustedCertEntityBuilder.java
@@ -72,7 +72,7 @@ public class TrustedCertEntityBuilder implements EntityBuilder {
             case DEPLOYMENT:
                 return entities.entrySet().stream()
                         .map(
-                                trustedCertEntry -> EntityBuilderHelper.getEntityWithOnlyMapping(TRUSTED_CERT_TYPE, trustedCertEntry.getKey(), idGenerator.generate())
+                                trustedCertEntry -> EntityBuilderHelper.getEntityWithOnlyMapping(TRUSTED_CERT_TYPE, trustedCertEntry.getKey(), generateCertificateId((TrustedCert)trustedCertEntry.getValue()))
                         ).collect(Collectors.toList());
             case ENVIRONMENT:
                 return entities.entrySet().stream().map(trustedCertEntry ->
@@ -84,7 +84,7 @@ public class TrustedCertEntityBuilder implements EntityBuilder {
     }
 
     private Entity buildTrustedCertEntity(String name, TrustedCert trustedCert, Map<String, SupplierWithIO<InputStream>> certificateFiles, Document document) {
-        final String id = idGenerator.generate();
+        final String id = generateCertificateId(trustedCert);
         trustedCert.setId(id);
         final Element trustedCertElem = createElementWithAttributesAndChildren(
                 document,
@@ -96,6 +96,13 @@ public class TrustedCertEntityBuilder implements EntityBuilder {
         buildAndAppendPropertiesElement(trustedCert.createProperties(), document, trustedCertElem);
 
         return EntityBuilderHelper.getEntityWithNameMapping(TRUSTED_CERT_TYPE, name, id, trustedCertElem);
+    }
+
+    private String generateCertificateId(TrustedCert trustedCert) {
+        if (trustedCert != null && trustedCert.getAnnotatedEntity() != null && trustedCert.getAnnotatedEntity().getId() != null) {
+            return trustedCert.getAnnotatedEntity().getId();
+        }
+        return idGenerator.generate();
     }
 
     private Element buildCertData(String name, TrustedCert trustedCert, Map<String, SupplierWithIO<InputStream>> certificateFiles, Document document) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/TrustedCertLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/TrustedCertLoader.java
@@ -6,15 +6,19 @@
 
 package com.ca.apim.gateway.cagatewayconfig.bundle.loader;
 
+import com.ca.apim.gateway.cagatewayconfig.beans.Annotation;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.TrustedCert;
 import com.ca.apim.gateway.cagatewayconfig.beans.TrustedCert.CertificateData;
+import com.ca.apim.gateway.cagatewayconfig.util.entity.AnnotationConstants;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
 import java.math.BigInteger;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.mapPropertiesElements;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
@@ -33,6 +37,11 @@ public class TrustedCertLoader implements BundleEntityLoader {
         TrustedCert cert = new TrustedCert(properties, getCertData(trustedCertElem));
         cert.setId(trustedCertElem.getAttribute(ATTRIBUTE_ID));
         cert.setName(getSingleChildElementTextContent(trustedCertElem, NAME));
+        Set<Annotation> annotations = new HashSet<>();
+        Annotation bundleEntity = new Annotation(AnnotationConstants.ANNOTATION_TYPE_BUNDLE_ENTITY);
+        bundleEntity.setId(trustedCertElem.getAttribute(ATTRIBUTE_ID));
+        annotations.add(bundleEntity);
+        cert.setAnnotations(annotations);
         bundle.getTrustedCerts().put(name, cert);
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
@@ -13,6 +13,7 @@ public class PolicyXMLElements {
 
     public static final String GOID_VALUE = "goidValue";
     public static final String STRING_VALUE = "stringValue";
+    public static final String GOID_ARRAY_VALUE = "goidArrayValue";
     public static final String INCLUDE = "L7p:Include";
     public static final String ENCAPSULATED = "L7p:Encapsulated";
     public static final String SET_VARIABLE = "L7p:SetVariable";
@@ -33,6 +34,10 @@ public class PolicyXMLElements {
     public static final String JMS_ROUTING_ASSERTION = "L7p:JmsRoutingAssertion";
     public static final String JMS_ENDPOINT_OID = "L7p:EndpointOid";
     public static final String JMS_ENDPOINT_NAME = "L7p:EndpointName";
+    public static final String HTTP_ROUTING_ASSERTION  = "L7p:HttpRoutingAssertion";
+    public static final String TLS_TRUSTED_CERT_IDS = "L7p:TlsTrustedCertGoids";
+    public static final String TLS_TRUSTED_CERT_NAMES = "L7p:TlsTrustedCertNames";
+    public static final String ITEM = "L7p:item";
 
     private PolicyXMLElements() {
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/TrustedCertLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/TrustedCertLoaderTest.java
@@ -28,7 +28,7 @@ import java.nio.charset.Charset;
 
 import static com.ca.apim.gateway.cagatewayconfig.beans.EntityUtils.createEntityInfo;
 import static com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoaderUtils.createEntityLoader;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 @Extensions({ @ExtendWith(MockitoExtension.class), @ExtendWith(TemporaryFolderExtension.class) })
 public class TrustedCertLoaderTest {
@@ -108,7 +108,10 @@ public class TrustedCertLoaderTest {
                 "    revocationCheckingEnabled: true\n" +
                 "    trustedForSigningClientCerts: true\n" +
                 "    trustedForSigningServerCerts: true\n" +
-                "    trustedAsSamlIssuer: false";
+                "    trustedAsSamlIssuer: false\n" +
+                "    annotations:\n" +
+                "    - type: \"@bundle-entity\"\n" +
+                "      id: \"28be78b936aa61bc75bd0df2089789cd\"";
         final File configFolder = rootProjectDir.createDirectory("config");
         final File identityProvidersFile = new File(configFolder, "trusted-certs.yml");
         Files.touch(identityProvidersFile);
@@ -120,6 +123,8 @@ public class TrustedCertLoaderTest {
         assertEquals(1, bundle.getTrustedCerts().size());
         final TrustedCert trustedCert = bundle.getTrustedCerts().get("fake-cert");
         assertEquals(8, trustedCert.createProperties().size());
+        assertNotNull(trustedCert.getAnnotatedEntity().getId());
+        assertEquals("28be78b936aa61bc75bd0df2089789cd", trustedCert.getAnnotatedEntity().getId());
     }
 
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/HttpRoutingAssertionSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/HttpRoutingAssertionSimplifier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 CA. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+package com.ca.apim.gateway.cagatewayexport.util.policy;
+
+import org.w3c.dom.Element;
+import javax.inject.Singleton;
+
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElement;
+
+/**
+ * Simplifier for the HTTP Routing Assertion.
+ */
+@Singleton
+public class HttpRoutingAssertionSimplifier implements PolicyAssertionSimplifier {
+
+    @Override
+    public void simplifyAssertionElement(PolicySimplifierContext context) {
+        Element httpRoutingAssertionElement = context.getAssertionElement();
+        final Element httpRoutingCertGoidsElement = getSingleChildElement(httpRoutingAssertionElement, TLS_TRUSTED_CERT_IDS, true);
+
+        // Remove trusted cert goid reference from routing assertion.
+        if (httpRoutingCertGoidsElement != null) {
+            httpRoutingAssertionElement.removeChild(httpRoutingCertGoidsElement);
+        }
+    }
+
+    @Override
+    public String getAssertionTagName() {
+        return HTTP_ROUTING_ASSERTION;
+    }
+}


### PR DESCRIPTION
Creating PR to merge changes from original PR https://github.com/CAAPIM/gateway-developer-plugin/pull/244

Fixes #
Fixed the environment id issue for trusted cert in HttpRouting assertion

## Proposed Changes
Making use of @bundle-entity annotation to populate the ID of environment entity at the time of loading

## Links
Link Type   | Link
------      | ------
Rally Issue | DE461108
Func Spec   | 
## Checklist
- [x] Pull Request Created
- [ ] Code Review Completed
- [ ] Veracode scan results addressed
- [ ] SonarQube scan results addressed
- [ ] TPSR has been submitted (if applicable) 
- [X] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
- [ ] Func Spec has been updated as needed
- [ ] Rally Issue(s) are in an engineering completed state 
