### PR TITLE
US676840 : portalTemplate flag support

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadata.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadata.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Collection;
 import java.util.LinkedList;
 
-@JsonPropertyOrder({"metaVersion", "id", "name", "groupName", "version", "type", "tags", "description", "reusable",
+@JsonPropertyOrder({"metaVersion", "id", "name", "groupName", "version", "type", "tags", "description", "portalTemplate", "reusable",
         "redeployable", "hasRouting", "environmentIncluded", "definedEntities", "environmentEntities", "dependencies"})
 public class BundleMetadata implements Metadata {
     @SuppressWarnings({"unused", "java:S1170"}) // Suppress IntelliJ warnings for this field
@@ -26,6 +26,7 @@ public class BundleMetadata implements Metadata {
     private String description;
     private Collection<Metadata> definedEntities;
     private Collection<String> tags;
+    private boolean portalTemplate;
     private boolean reusable;
     private boolean redeployable;
     private boolean hasRouting;
@@ -83,6 +84,10 @@ public class BundleMetadata implements Metadata {
         return tags;
     }
 
+    public boolean isPortalTemplate() {
+        return portalTemplate;
+    }
+
     public boolean isReusable() {
         return reusable;
     }
@@ -114,6 +119,7 @@ public class BundleMetadata implements Metadata {
         private String groupName;
         private final String version;
         private String description;
+        private boolean portalTemplate;
         private boolean reusable;
         private boolean redeployable;
         private boolean hasRouting;
@@ -154,6 +160,11 @@ public class BundleMetadata implements Metadata {
             return this;
         }
 
+        public Builder portalTemplate(boolean portalTemplate) {
+            this.portalTemplate = portalTemplate;
+            return this;
+        }
+
         public Builder reusableAndRedeployable(boolean reusable, boolean redeployable) {
             this.reusable = reusable;
             this.redeployable = redeployable;
@@ -179,6 +190,7 @@ public class BundleMetadata implements Metadata {
             BundleMetadata bundleMetadata = new BundleMetadata(type, id, name, groupName, version);
             bundleMetadata.description = description;
             bundleMetadata.definedEntities = definedEntities;
+            bundleMetadata.portalTemplate = portalTemplate;
             bundleMetadata.reusable = reusable;
             bundleMetadata.redeployable = redeployable;
             bundleMetadata.hasRouting = hasRouting;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadata.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadata.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Collection;
 import java.util.LinkedList;
 
-@JsonPropertyOrder({"metaVersion", "id", "name", "groupName", "version", "type", "tags", "description", "portalTemplate", "reusable",
+@JsonPropertyOrder({"metaVersion", "id", "name", "groupName", "version", "type", "tags", "description", "l7Template", "reusable",
         "redeployable", "hasRouting", "environmentIncluded", "definedEntities", "environmentEntities", "dependencies"})
 public class BundleMetadata implements Metadata {
     @SuppressWarnings({"unused", "java:S1170"}) // Suppress IntelliJ warnings for this field
@@ -26,7 +26,7 @@ public class BundleMetadata implements Metadata {
     private String description;
     private Collection<Metadata> definedEntities;
     private Collection<String> tags;
-    private boolean portalTemplate;
+    private boolean l7Template;
     private boolean reusable;
     private boolean redeployable;
     private boolean hasRouting;
@@ -84,8 +84,8 @@ public class BundleMetadata implements Metadata {
         return tags;
     }
 
-    public boolean isPortalTemplate() {
-        return portalTemplate;
+    public boolean isL7Template() {
+        return l7Template;
     }
 
     public boolean isReusable() {
@@ -119,7 +119,7 @@ public class BundleMetadata implements Metadata {
         private String groupName;
         private final String version;
         private String description;
-        private boolean portalTemplate;
+        private boolean l7Template;
         private boolean reusable;
         private boolean redeployable;
         private boolean hasRouting;
@@ -160,8 +160,8 @@ public class BundleMetadata implements Metadata {
             return this;
         }
 
-        public Builder portalTemplate(boolean portalTemplate) {
-            this.portalTemplate = portalTemplate;
+        public Builder l7Template(boolean l7Template) {
+            this.l7Template = l7Template;
             return this;
         }
 
@@ -190,7 +190,7 @@ public class BundleMetadata implements Metadata {
             BundleMetadata bundleMetadata = new BundleMetadata(type, id, name, groupName, version);
             bundleMetadata.description = description;
             bundleMetadata.definedEntities = definedEntities;
-            bundleMetadata.portalTemplate = portalTemplate;
+            bundleMetadata.l7Template = l7Template;
             bundleMetadata.reusable = reusable;
             bundleMetadata.redeployable = redeployable;
             bundleMetadata.hasRouting = hasRouting;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
@@ -62,7 +62,7 @@ public class BundleMetadataBuilder {
             builder.environmentEntities(getEnvironmentDependenciesMetadata(dependentEntities));
             builder.dependencies(annotatedBundle.getDependentBundles());
             builder.tags(annotatedEntity.getTags());
-            builder.portalTemplate(Boolean.valueOf(encass.getProperties().get(PORTAL_TEMPLATE).toString()));
+            builder.portalTemplate(Boolean.valueOf(String.valueOf(encass.getProperties().get(PORTAL_TEMPLATE))));
             builder.reusableAndRedeployable(true, annotatedEntity.isRedeployable() || !isBundleContainsReusableEntity(annotatedBundle));
             builder.hasRouting(hasRoutingAssertion(dependentEntities));
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PORTAL_TEMPLATE;
 
 @Singleton
 public class BundleMetadataBuilder {
@@ -61,7 +62,7 @@ public class BundleMetadataBuilder {
             builder.environmentEntities(getEnvironmentDependenciesMetadata(dependentEntities));
             builder.dependencies(annotatedBundle.getDependentBundles());
             builder.tags(annotatedEntity.getTags());
-            builder.portalTemplate(Boolean.valueOf(encass.getProperties().get("portalTemplate").toString()));
+            builder.portalTemplate(Boolean.valueOf(encass.getProperties().get(PORTAL_TEMPLATE).toString()));
             builder.reusableAndRedeployable(true, annotatedEntity.isRedeployable() || !isBundleContainsReusableEntity(annotatedBundle));
             builder.hasRouting(hasRoutingAssertion(dependentEntities));
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.*;
-import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PORTAL_TEMPLATE;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.L7_TEMPLATE;
 
 @Singleton
 public class BundleMetadataBuilder {
@@ -62,7 +62,7 @@ public class BundleMetadataBuilder {
             builder.environmentEntities(getEnvironmentDependenciesMetadata(dependentEntities));
             builder.dependencies(annotatedBundle.getDependentBundles());
             builder.tags(annotatedEntity.getTags());
-            builder.portalTemplate(Boolean.valueOf(String.valueOf(encass.getProperties().get(PORTAL_TEMPLATE))));
+            builder.l7Template(Boolean.valueOf(String.valueOf(encass.getProperties().get(L7_TEMPLATE))));
             builder.reusableAndRedeployable(true, annotatedEntity.isRedeployable() || !isBundleContainsReusableEntity(annotatedBundle));
             builder.hasRouting(hasRoutingAssertion(dependentEntities));
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
@@ -61,6 +61,7 @@ public class BundleMetadataBuilder {
             builder.environmentEntities(getEnvironmentDependenciesMetadata(dependentEntities));
             builder.dependencies(annotatedBundle.getDependentBundles());
             builder.tags(annotatedEntity.getTags());
+            builder.portalTemplate(Boolean.valueOf(encass.getProperties().get("portalTemplate").toString()));
             builder.reusableAndRedeployable(true, annotatedEntity.isRedeployable() || !isBundleContainsReusableEntity(annotatedBundle));
             builder.hasRouting(hasRoutingAssertion(dependentEntities));
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
@@ -43,6 +43,7 @@ public class PolicyXMLElements {
     public static final String ACTIVE_CONNECTOR_GOID = "L7p:SsgActiveConnectorGoid";
     public static final String ACTIVE_CONNECTOR_NAME = "L7p:SsgActiveConnectorName";
     public static final String ITEM = "L7p:item";
+    public static final String ENABLED = "L7p:Enabled";
 
     private PolicyXMLElements() {
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
@@ -25,6 +25,7 @@ public class PolicyXMLElements {
     public static final String EXPRESSION = "L7p:Expression";
     public static final String ENCAPSULATED_ASSERTION_CONFIG_GUID = "L7p:EncapsulatedAssertionConfigGuid";
     public static final String ENCAPSULATED_ASSERTION_CONFIG_NAME = "L7p:EncapsulatedAssertionConfigName";
+    public static final String API_PORTAL_ENCASS_INTEGRATION = "L7p:ApiPortalEncassIntegration";
     public static final String POLICY_GUID = "L7p:PolicyGuid";
     public static final String NO_OP_IF_CONFIG_MISSING = "L7p:NoOpIfConfigMissing";
     public static final String AUTHENTICATION = "L7p:Authentication";

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/properties/PropertyConstants.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/properties/PropertyConstants.java
@@ -39,6 +39,7 @@ public class PropertyConstants {
     public static final String PASS_METRICS_TO_PARENT = "passMetricsToParent";
     public static final String DESCRIPTION = "description";
     public static final String DEFAULT_PALETTE_FOLDER_LOCATION = "internalAssertions";
+    public static final String PORTAL_TEMPLATE = "portalTemplate";
 
     // Property names
     public static final String PROPERTY_USER = "user";

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/properties/PropertyConstants.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/properties/PropertyConstants.java
@@ -39,7 +39,7 @@ public class PropertyConstants {
     public static final String PASS_METRICS_TO_PARENT = "passMetricsToParent";
     public static final String DESCRIPTION = "description";
     public static final String DEFAULT_PALETTE_FOLDER_LOCATION = "internalAssertions";
-    public static final String PORTAL_TEMPLATE = "portalTemplate";
+    public static final String L7_TEMPLATE = "l7Template";
 
     // Property names
     public static final String PROPERTY_USER = "user";

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
@@ -107,7 +107,7 @@ public class BundleEntityBuilderTestHelper {
             put(ALLOW_TRACING, "false");
             put(DESCRIPTION, "someDescription");
             put(PASS_METRICS_TO_PARENT, "false");
-            put(PORTAL_TEMPLATE, "true");
+            put(L7_TEMPLATE, "true");
         }});
         return encass;
     }
@@ -126,7 +126,7 @@ public class BundleEntityBuilderTestHelper {
             put(ALLOW_TRACING, "false");
             put(DESCRIPTION, "someDescription");
             put(PASS_METRICS_TO_PARENT, "false");
-            put(PORTAL_TEMPLATE, "false");
+            put(L7_TEMPLATE, "false");
         }});
         return encass;
     }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
@@ -101,12 +101,14 @@ public class BundleEntityBuilderTestHelper {
             annotations.add(AnnotableEntity.REDEPLOYABLE_ANNOTATION);
         }
         encass.setAnnotations(annotations);
-        encass.setProperties(ImmutableMap.of(
-                PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION,
-                PALETTE_ICON_RESOURCE_NAME, "someImage",
-                ALLOW_TRACING, "false",
-                DESCRIPTION, "someDescription",
-                PASS_METRICS_TO_PARENT, "false"));
+        encass.setProperties(new HashMap<String, Object>() {{
+            put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
+            put(PALETTE_ICON_RESOURCE_NAME, "someImage");
+            put(ALLOW_TRACING, "false");
+            put(DESCRIPTION, "someDescription");
+            put(PASS_METRICS_TO_PARENT, "false");
+            put(PORTAL_TEMPLATE, "true");
+        }});
         return encass;
     }
 
@@ -118,12 +120,14 @@ public class BundleEntityBuilderTestHelper {
         encass.setId(encassId);
         encass.setGuid(encassGuid);
         encass.setAnnotations(annotations);
-        encass.setProperties(ImmutableMap.of(
-                PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION,
-                PALETTE_ICON_RESOURCE_NAME, "someImage",
-                ALLOW_TRACING, "false",
-                DESCRIPTION, "someDescription",
-                PASS_METRICS_TO_PARENT, "false"));
+        encass.setProperties(new HashMap<String, Object>() {{
+            put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
+            put(PALETTE_ICON_RESOURCE_NAME, "someImage");
+            put(ALLOW_TRACING, "false");
+            put(DESCRIPTION, "someDescription");
+            put(PASS_METRICS_TO_PARENT, "false");
+            put(PORTAL_TEMPLATE, "false");
+        }});
         return encass;
     }
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilderTest.java
@@ -169,7 +169,7 @@ public class BundleMetadataBuilderTest {
         assertEquals(TEST_ENCASS_ANNOTATION_NAME, metadata.getName());
         assertEquals(TEST_ENCASS_ANNOTATION_DESC, metadata.getDescription());
         assertEquals(TEST_ENCASS_ANNOTATION_TAGS, metadata.getTags());
-        assertTrue(metadata.isPortalTemplate());
+        assertTrue(metadata.isL7Template());
 
         verifyAnnotatedEncassBundleMetadata(bundles, bundle, encass, false, false, true);
     }
@@ -247,7 +247,7 @@ public class BundleMetadataBuilderTest {
         assertEquals(Collections.emptyList(), metadata.getTags());
         assertTrue(metadata.isReusable());
         assertTrue(metadata.isRedeployable());
-        assertFalse(metadata.isPortalTemplate());
+        assertFalse(metadata.isL7Template());
 
         Collection<Metadata> definedEntities = metadata.getDefinedEntities();
         assertEquals(2, definedEntities.size());

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilderTest.java
@@ -169,6 +169,7 @@ public class BundleMetadataBuilderTest {
         assertEquals(TEST_ENCASS_ANNOTATION_NAME, metadata.getName());
         assertEquals(TEST_ENCASS_ANNOTATION_DESC, metadata.getDescription());
         assertEquals(TEST_ENCASS_ANNOTATION_TAGS, metadata.getTags());
+        assertTrue(metadata.isPortalTemplate());
 
         verifyAnnotatedEncassBundleMetadata(bundles, bundle, encass, false, false, true);
     }
@@ -246,6 +247,7 @@ public class BundleMetadataBuilderTest {
         assertEquals(Collections.emptyList(), metadata.getTags());
         assertTrue(metadata.isReusable());
         assertTrue(metadata.isRedeployable());
+        assertFalse(metadata.isPortalTemplate());
 
         Collection<Metadata> definedEntities = metadata.getDefinedEntities();
         assertEquals(2, definedEntities.size());

--- a/gateway-developer-plugin/src/test/resources/example-project-generating-environment/src/main/gateway/config/encass.yml
+++ b/gateway-developer-plugin/src/test/resources/example-project-generating-environment/src/main/gateway/config/encass.yml
@@ -10,4 +10,4 @@ encass_env:
     allowTracing: "true"
     description: "Encass to validate."
     passMetricsToParent: "false"
-    portalTemplate: "false"
+    l7Template: "false"

--- a/gateway-developer-plugin/src/test/resources/example-project-generating-environment/src/main/gateway/config/encass.yml
+++ b/gateway-developer-plugin/src/test/resources/example-project-generating-environment/src/main/gateway/config/encass.yml
@@ -10,3 +10,4 @@ encass_env:
     allowTracing: "true"
     description: "Encass to validate."
     passMetricsToParent: "false"
+    portalTemplate: "false"

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
@@ -9,21 +9,16 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.Encass;
 import com.ca.apim.gateway.cagatewayconfig.beans.Policy;
-import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayexport.util.policy.EncassPolicyXMLSimplifier;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PORTAL_TEMPLATE;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.L7_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayexport.tasks.explode.linker.PolicyLinker.getPolicyPath;
 
 @Singleton
 public class EncassLinker implements EntityLinker<Encass> {
-    private static final Logger LOGGER = Logger.getLogger(EncassLinker.class.getName());
     private final EncassPolicyXMLSimplifier encassPolicyXMLSimplifier;
 
     @Inject
@@ -43,13 +38,7 @@ public class EncassLinker implements EntityLinker<Encass> {
             throw new LinkerException("Could not find policy for Encapsulated Assertion: " + encass.getName() + ". Policy ID: " + encass.getPolicyId());
         }
 
-        String portalTemplate = "false";
-        try {
-            portalTemplate = encassPolicyXMLSimplifier.simplifyEncassPolicyXML(policy.getPolicyDocument());
-        } catch (DocumentParseException e) {
-            LOGGER.log(Level.INFO, "ApiPortalEncassIntegration assertion is not found in encass policy : {0}, setting portalTemplate as false : ", policy.getName());
-        }
-        encass.getProperties().put(PORTAL_TEMPLATE, portalTemplate);
+        encass.getProperties().put(L7_TEMPLATE, encassPolicyXMLSimplifier.simplifyEncassPolicyXML(policy));
         encass.setPolicy(policy.getPath());
         encass.setPath(getPolicyPath(policy, bundle, encass));
     }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
@@ -15,8 +15,8 @@ import org.w3c.dom.Element;
 import javax.inject.Singleton;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.API_PORTAL_ENCASS_INTEGRATION;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PORTAL_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
-import static com.ca.apim.gateway.cagatewayexport.tasks.explode.linker.LinkerConstants.PORTAL_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayexport.tasks.explode.linker.PolicyLinker.getPolicyPath;
 
 @Singleton

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
@@ -9,9 +9,14 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.Encass;
 import com.ca.apim.gateway.cagatewayconfig.beans.Policy;
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
+import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
 
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.API_PORTAL_ENCASS_INTEGRATION;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
+import static com.ca.apim.gateway.cagatewayexport.tasks.explode.linker.LinkerConstants.PORTAL_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayexport.tasks.explode.linker.PolicyLinker.getPolicyPath;
 
 @Singleton
@@ -27,6 +32,16 @@ public class EncassLinker implements EntityLinker<Encass> {
         if (policy == null) {
             throw new LinkerException("Could not find policy for Encapsulated Assertion: " + encass.getName() + ". Policy ID: " + encass.getPolicyId());
         }
+        Element encassPortalIntegrationElement = null;
+        try {
+            encassPortalIntegrationElement = getSingleElement(policy.getPolicyDocument(), API_PORTAL_ENCASS_INTEGRATION);
+        } catch (DocumentParseException ex) {
+            // do nothing
+        }
+        if (encassPortalIntegrationElement != null) {
+            policy.getPolicyDocument().getFirstChild().removeChild(encassPortalIntegrationElement);
+        }
+        encass.getProperties().put(PORTAL_TEMPLATE, encassPortalIntegrationElement != null ? "true" : "false");
         encass.setPolicy(policy.getPath());
         encass.setPath(getPolicyPath(policy, bundle, encass));
     }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
@@ -14,8 +14,9 @@ import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
 
-import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.API_PORTAL_ENCASS_INTEGRATION;
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PORTAL_TEMPLATE;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElement;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
 import static com.ca.apim.gateway.cagatewayexport.tasks.explode.linker.PolicyLinker.getPolicyPath;
 
@@ -33,15 +34,17 @@ public class EncassLinker implements EntityLinker<Encass> {
             throw new LinkerException("Could not find policy for Encapsulated Assertion: " + encass.getName() + ". Policy ID: " + encass.getPolicyId());
         }
         Element encassPortalIntegrationElement = null;
+        Element encassPortalIntegrationEnabledElement = null;
         try {
             encassPortalIntegrationElement = getSingleElement(policy.getPolicyDocument(), API_PORTAL_ENCASS_INTEGRATION);
         } catch (DocumentParseException ex) {
             // do nothing
         }
         if (encassPortalIntegrationElement != null) {
+            encassPortalIntegrationEnabledElement = getSingleChildElement(encassPortalIntegrationElement, ENABLED, true);
             policy.getPolicyDocument().getFirstChild().removeChild(encassPortalIntegrationElement);
         }
-        encass.getProperties().put(PORTAL_TEMPLATE, encassPortalIntegrationElement != null ? "true" : "false");
+        encass.getProperties().put(PORTAL_TEMPLATE, encassPortalIntegrationElement != null && encassPortalIntegrationEnabledElement == null ? "true" : "false");
         encass.setPolicy(policy.getPath());
         encass.setPath(getPolicyPath(policy, bundle, encass));
     }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/LinkerConstants.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/LinkerConstants.java
@@ -13,6 +13,7 @@ final class LinkerConstants {
     
     static final Pattern STORED_PASSWORD_PATTERN = Pattern.compile("secpass.(.+?).plaintext");
     static final String ENCRYPTED_PASSWORD_PREFIX = "$L7C2$";
+    static final String PORTAL_TEMPLATE = "portalTemplate";
     
     private LinkerConstants() {
     }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/LinkerConstants.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/LinkerConstants.java
@@ -13,7 +13,6 @@ final class LinkerConstants {
     
     static final Pattern STORED_PASSWORD_PATTERN = Pattern.compile("secpass.(.+?).plaintext");
     static final String ENCRYPTED_PASSWORD_PREFIX = "$L7C2$";
-    static final String PORTAL_TEMPLATE = "portalTemplate";
     
     private LinkerConstants() {
     }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/EncassPolicyXMLSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/EncassPolicyXMLSimplifier.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018 CA. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+package com.ca.apim.gateway.cagatewayexport.util.policy;
+
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
+import org.w3c.dom.Element;
+
+import javax.inject.Singleton;
+
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.API_PORTAL_ENCASS_INTEGRATION;
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.ENABLED;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElement;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
+
+/**
+ * This class is responsible for removing the L7p:ApiPortalEncassIntegration assertion from encass backed policy.
+ */
+@Singleton
+public class EncassPolicyXMLSimplifier {
+    /**
+     *
+     * @param policyElement
+     * @return true if ApiPortalEncassIntegration assertion is present and enabled else false
+     * @throws DocumentParseException
+     */
+    public String simplifyEncassPolicyXML(Element policyElement) throws DocumentParseException {
+        Element encassPortalIntegrationElement = null;
+        Element encassPortalIntegrationEnabledElement = null;
+        encassPortalIntegrationElement = getSingleElement(policyElement, API_PORTAL_ENCASS_INTEGRATION);
+
+        if (encassPortalIntegrationElement != null) {
+            encassPortalIntegrationEnabledElement = getSingleChildElement(encassPortalIntegrationElement, ENABLED, true);
+            policyElement.getFirstChild().removeChild(encassPortalIntegrationElement);
+        }
+        return encassPortalIntegrationElement != null && encassPortalIntegrationEnabledElement == null ? "true" : "false";
+    }
+}

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/EncassPolicyXMLSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/EncassPolicyXMLSimplifier.java
@@ -6,10 +6,13 @@
 
 package com.ca.apim.gateway.cagatewayexport.util.policy;
 
+import com.ca.apim.gateway.cagatewayconfig.beans.Policy;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.API_PORTAL_ENCASS_INTEGRATION;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.ENABLED;
@@ -21,20 +24,25 @@ import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSing
  */
 @Singleton
 public class EncassPolicyXMLSimplifier {
+    private static final Logger LOGGER = Logger.getLogger(EncassPolicyXMLSimplifier.class.getName());
     /**
      *
-     * @param policyElement
-     * @return true if ApiPortalEncassIntegration assertion is present and enabled else false
-     * @throws DocumentParseException
+     * @param policy encass policy.
+     * @return true if ApiPortalEncassIntegration assertion is present and enabled else false.
      */
-    public String simplifyEncassPolicyXML(Element policyElement) throws DocumentParseException {
+    public String simplifyEncassPolicyXML(Policy policy) {
         Element encassPortalIntegrationElement = null;
         Element encassPortalIntegrationEnabledElement = null;
-        encassPortalIntegrationElement = getSingleElement(policyElement, API_PORTAL_ENCASS_INTEGRATION);
+        try {
+            encassPortalIntegrationElement = getSingleElement(policy.getPolicyDocument(), API_PORTAL_ENCASS_INTEGRATION);
+        } catch (DocumentParseException e) {
+            LOGGER.log(Level.INFO, "ApiPortalEncassIntegration assertion is not found in encass policy : {0}, setting portalTemplate as false : ", policy.getName());
+        }
 
         if (encassPortalIntegrationElement != null) {
+            Element encassPortalIntegrationParentElement = (Element) encassPortalIntegrationElement.getParentNode();
             encassPortalIntegrationEnabledElement = getSingleChildElement(encassPortalIntegrationElement, ENABLED, true);
-            policyElement.getFirstChild().removeChild(encassPortalIntegrationElement);
+            encassPortalIntegrationParentElement.removeChild(encassPortalIntegrationElement);
         }
         return encassPortalIntegrationElement != null && encassPortalIntegrationEnabledElement == null ? "true" : "false";
     }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinkerTest.java
@@ -6,22 +6,35 @@
 
 package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 
-import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
-import com.ca.apim.gateway.cagatewayconfig.beans.Encass;
-import com.ca.apim.gateway.cagatewayconfig.beans.Folder;
-import com.ca.apim.gateway.cagatewayconfig.beans.FolderTree;
+import com.ca.apim.gateway.cagatewayconfig.beans.*;
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.API_PORTAL_ENCASS_INTEGRATION;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
 import static com.ca.apim.gateway.cagatewayexport.util.TestUtils.*;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class EncassLinkerTest {
     private EncassLinker encassLinker;
     private Encass myEncass;
     private Bundle bundle;
+    private static final String ENCASS_POLICY_WITH_PORTAL_INTEGRATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<wsp:Policy xmlns:L7p=\"http://www.layer7tech.com/ws/policy\" xmlns:wsp=\"http://schemas.xmlsoap.org/ws/2002/12/policy\">\n" +
+            "    <wsp:All wsp:Usage=\"Required\">\n" +
+            "        <L7p:ApiPortalEncassIntegration/>\n" +
+            "        <L7p:CommentAssertion>\n" +
+            "            <L7p:Comment stringValue=\"Policy Fragment: includedPolicy\"/>\n" +
+            "        </L7p:CommentAssertion>\n" +
+            "    </wsp:All>\n" +
+            "</wsp:Policy>";
 
     @BeforeEach
     void setUp() {
@@ -69,5 +82,27 @@ class EncassLinkerTest {
         fullBundle.setFolderTree(folderTree);
 
         assertThrows(LinkerException.class, () -> encassLinker.link(bundle, fullBundle));
+    }
+
+    @Test
+    void linkPortalTemplateFlag() throws DocumentParseException {
+        Bundle fullBundle = new Bundle();
+        myEncass.setProperties(new HashMap<String, Object>() {{
+            put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
+        }});
+        fullBundle.addEntity(myEncass);
+        fullBundle.addEntity(createPolicy("myEncassPolicy", "1","1", "1", DocumentUtils.stringToXML(DocumentTools.INSTANCE, ENCASS_POLICY_WITH_PORTAL_INTEGRATION), EMPTY));
+        fullBundle.addEntity(createFolder("myFolder", "1", null));
+
+        FolderTree folderTree = new FolderTree(fullBundle.getEntities(Folder.class).values());
+        fullBundle.setFolderTree(folderTree);
+        encassLinker.link(bundle, fullBundle);
+        Encass linkedEncass = bundle.getEntities(Encass.class).get("1");
+        assertEquals("myEncassPolicy", linkedEncass.getPath());
+        assertEquals(2, linkedEncass.getProperties().size());
+        assertTrue(Boolean.valueOf(linkedEncass.getProperties().get(PORTAL_TEMPLATE).toString()));
+
+        Policy updatedPolicy =  fullBundle.getEntities(Policy.class).get("1");
+        assertThrows(DocumentParseException.class, () -> getSingleElement(updatedPolicy.getPolicyDocument(), API_PORTAL_ENCASS_INTEGRATION));
     }
 }


### PR DESCRIPTION
## Description

Export Task: If encass policy contains "Set As Portal Publishable Fragment" assertion reference, remove it from the policy and set the portalTemplate property to true. 
XML Identity for this assertion is <L7p:ApiPortalEncassIntegration/>

Build-Bundle Task: Generated metadata should contain the new flag (portalTemplate) as per the ENCASS definition. This way, portal determines whether the bundle is a portal-friendly resuable template or not.


## Links
Link Type   | Link
------      | ------
Rally Issue | 
Func Spec   | 
## Checklist
- [x] Pull Request Created
- [ ] Code Review Completed
- [ ] Veracode scan results addressed
- [ ] SonarQube scan results addressed
- [ ] TPSR has been submitted (if applicable) 
- [X] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
- [ ] Func Spec has been updated as needed
- [ ] Rally Issue(s) are in an engineering completed state 