### PR TITLE
Feature/us662948 revisting shared annotation

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Bundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Bundle.java
@@ -313,8 +313,23 @@ public class Bundle {
      * @return String
      */
     public String applyUniqueName(final String entityName, final EntityBuilder.BundleType bundleType) {
+        return applyUniqueName(entityName, bundleType, false);
+    }
+
+    /**
+     * Applies unique name space and version to the given entity name
+     * ::namespace::entityName::majorVersion.minorVersion
+     * If the entity or entity's parent is Shared entity, "namespace" is just the Project group name.
+     *
+     * @param entityName Entity name
+     * @param bundleType Bundle type
+     * @param isShared   Is shared entity
+     * @return Unique entity name
+     */
+    public String applyUniqueName(final String entityName, final EntityBuilder.BundleType bundleType,
+                                  boolean isShared) {
         StringBuilder uniqueName = new StringBuilder(UNIQUE_NAME_SEPARATOR);
-        uniqueName.append(getNamespace(bundleType));
+        uniqueName.append(getNamespace(bundleType, isShared));
         uniqueName.append(UNIQUE_NAME_SEPARATOR);
         uniqueName.append(entityName);
 
@@ -330,7 +345,17 @@ public class Bundle {
         return uniqueName.toString();
     }
 
-    public String getNamespace(final EntityBuilder.BundleType bundleType) {
+    /**
+     * Returns namespace for the entity for unique naming.
+     *
+     * For non-shared entities, it returns &lt;groupName&lt;.&gt;bundleName&gt;
+     * For shared entities and non-annotated bundle, it returns just &lt;groupName&gt;
+     *
+     * @param bundleType bundle type
+     * @param isShared is a shared entity (or is any parent entity is Shared)
+     * @return namespace
+     */
+    public String getNamespace(final EntityBuilder.BundleType bundleType, boolean isShared) {
         return getProjectInfo().getGroupName();
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -14,7 +14,6 @@ import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
@@ -24,11 +23,9 @@ import java.io.File;
 import java.util.*;
 
 import static com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile.FileType.JSON_YAML;
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 import static java.util.stream.Collectors.toCollection;
 
-@JsonInclude(NON_NULL)
 @Named("ENCAPSULATED_ASSERTION")
 @ConfigurationFile(name = "encass", type = JSON_YAML)
 @EnvironmentType("ENCAPSULATED_ASSERTION")
@@ -52,7 +49,7 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
 
     /* Set to true if any Parent (Policy or Encass) in hierarchy is annotated with @shared */
     @JsonIgnore
-    private boolean isParentEntityShared;
+    private boolean parentEntityShared;
 
     public Encass() { }
 
@@ -126,11 +123,11 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     }
 
     public boolean isParentEntityShared() {
-        return isParentEntityShared;
+        return parentEntityShared;
     }
 
     public void setParentEntityShared(boolean parentEntityShared) {
-        isParentEntityShared = parentEntityShared;
+        this.parentEntityShared = parentEntityShared;
     }
 
     Encass merge(Encass otherEncass) {
@@ -157,48 +154,6 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     @Override
     public void preWrite(File configFolder, DocumentFileUtils documentFileUtils) {
         sortArgumentsAndResults();
-    }
-
-    @JsonIgnore
-    @Override
-    public Metadata getMetadata() {
-        return new Metadata() {
-            @Override
-            public String getType() {
-                return EntityTypes.ENCAPSULATED_ASSERTION_TYPE;
-            }
-
-            @Override
-            public String getName() {
-                return Encass.this.getName();
-            }
-
-            @Override
-            public String getId() {
-                AnnotatedEntity annotatedEntity = getAnnotatedEntity();
-                if (annotatedEntity != null && StringUtils.isNotBlank(annotatedEntity.getId())) {
-                    return annotatedEntity.getId();
-                }
-                return Encass.this.getId();
-            }
-
-            @Override
-            public String getGuid() {
-                AnnotatedEntity annotatedEntity = getAnnotatedEntity();
-                if (annotatedEntity != null && StringUtils.isNotBlank(annotatedEntity.getGuid())) {
-                    return annotatedEntity.getGuid();
-                }
-                return Encass.this.getGuid();
-            }
-
-            public Set<EncassArgument> getArguments() {
-                return Encass.this.getArguments();
-            }
-
-            public Set<EncassResult> getResults() {
-                return Encass.this.getResults();
-            }
-        };
     }
 
     @VisibleForTesting

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -52,7 +52,9 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
 
     /* Set to true if any Parent (Policy or Encass) in hierarchy is annotated with @shared */
     @JsonIgnore
-    private boolean isParentEntityShared;
+    private boolean parentEntityShared;
+    @JsonIgnore
+    private String uniqueEntityName;
 
     public Encass() { }
 
@@ -126,11 +128,19 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     }
 
     public boolean isParentEntityShared() {
-        return isParentEntityShared;
+        return parentEntityShared;
     }
 
     public void setParentEntityShared(boolean parentEntityShared) {
-        isParentEntityShared = parentEntityShared;
+        this.parentEntityShared = parentEntityShared;
+    }
+
+    public String getUniqueEntityName() {
+        return uniqueEntityName;
+    }
+
+    public void setUniqueEntityName(String uniqueEntityName) {
+        this.uniqueEntityName = uniqueEntityName;
     }
 
     Encass merge(Encass otherEncass) {
@@ -170,6 +180,9 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
 
             @Override
             public String getName() {
+                if (StringUtils.isNotBlank(getUniqueEntityName())) {
+                    return getUniqueEntityName();
+                }
                 return Encass.this.getName();
             }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -176,7 +176,7 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
             @Override
             public String getId() {
                 AnnotatedEntity annotatedEntity = getAnnotatedEntity();
-                if (annotatedEntity != null && annotatedEntity.getId() != null) {
+                if (annotatedEntity != null && StringUtils.isNotBlank(annotatedEntity.getId())) {
                     return annotatedEntity.getId();
                 }
                 return Encass.this.getId();
@@ -185,7 +185,7 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
             @Override
             public String getGuid() {
                 AnnotatedEntity annotatedEntity = getAnnotatedEntity();
-                if (annotatedEntity != null && annotatedEntity.getGuid() != null) {
+                if (annotatedEntity != null && StringUtils.isNotBlank(annotatedEntity.getGuid())) {
                     return annotatedEntity.getGuid();
                 }
                 return Encass.this.getGuid();

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -21,13 +21,11 @@ import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Named;
 import java.io.File;
-import java.util.Comparator;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 import static com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile.FileType.JSON_YAML;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 import static java.util.stream.Collectors.toCollection;
 
 @JsonInclude(NON_NULL)
@@ -40,9 +38,9 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     private String policy;
     private Set<EncassArgument> arguments;
     private Set<EncassResult> results;
-    private Map<String, Object> properties;
+    private Map<String, Object> properties = new HashMap<>();
     @JsonDeserialize(using = AnnotationDeserializer.class)
-    private Set<Annotation> annotations;
+    private Set<Annotation> annotations = new HashSet<>();
     @JsonIgnore
     private String guid;
     @JsonIgnore
@@ -51,6 +49,16 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     private String path;
     @JsonIgnore
     private AnnotatedEntity<? extends GatewayEntity> annotatedEntity;
+
+    /* Set to true if any Parent (Policy or Encass) in hierarchy is annotated with @shared */
+    @JsonIgnore
+    private boolean isParentEntityShared;
+
+    public Encass() { }
+
+    public Encass(Encass otherEncass) {
+        merge(otherEncass);
+    }
 
     public Set<EncassArgument> getArguments() {
         return arguments;
@@ -115,6 +123,28 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
 
     public void setPath(String path) {
         this.path = path;
+    }
+
+    public boolean isParentEntityShared() {
+        return isParentEntityShared;
+    }
+
+    public void setParentEntityShared(boolean parentEntityShared) {
+        isParentEntityShared = parentEntityShared;
+    }
+
+    Encass merge(Encass otherEncass) {
+        this.guid = firstNonNull(otherEncass.guid, this.guid);
+        this.setName(firstNonNull(otherEncass.getName(), this.getName()));
+        this.setId(firstNonNull(otherEncass.getId(), this.getId()));
+        this.properties.putAll(firstNonNull(otherEncass.properties, Collections.emptyMap()));
+        this.policy = firstNonNull(otherEncass.policy, this.policy);
+        this.path = firstNonNull(otherEncass.path, this.path);
+        this.arguments = firstNonNull(firstNonNull(otherEncass.arguments, Collections.emptySet()));
+        this.results = firstNonNull(firstNonNull(otherEncass.results, Collections.emptySet()));
+        this.policyId = firstNonNull(otherEncass.policyId, this.policyId);
+        this.annotations.addAll(firstNonNull(otherEncass.annotations, Collections.emptySet()));
+        return this;
     }
 
     @Override
@@ -201,5 +231,22 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     @Override
     public String getEntityType() {
         return EntityTypes.ENCAPSULATED_ASSERTION_TYPE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Encass)) {
+            return false;
+        }
+        Encass encass = (Encass) o;
+        return Objects.equals(getName(), encass.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -59,7 +59,16 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     public Encass() { }
 
     public Encass(Encass otherEncass) {
-        merge(otherEncass);
+        this.guid = firstNonNull(otherEncass.guid, this.guid);
+        this.setName(firstNonNull(otherEncass.getName(), this.getName()));
+        this.setId(firstNonNull(otherEncass.getId(), this.getId()));
+        this.properties.putAll(firstNonNull(otherEncass.properties, Collections.emptyMap()));
+        this.policy = firstNonNull(otherEncass.policy, this.policy);
+        this.path = firstNonNull(otherEncass.path, this.path);
+        this.arguments = firstNonNull(firstNonNull(otherEncass.arguments, Collections.emptySet()));
+        this.results = firstNonNull(firstNonNull(otherEncass.results, Collections.emptySet()));
+        this.policyId = firstNonNull(otherEncass.policyId, this.policyId);
+        this.annotations.addAll(firstNonNull(otherEncass.annotations, Collections.emptySet()));
     }
 
     public Set<EncassArgument> getArguments() {
@@ -141,20 +150,6 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
 
     public void setUniqueEntityName(String uniqueEntityName) {
         this.uniqueEntityName = uniqueEntityName;
-    }
-
-    Encass merge(Encass otherEncass) {
-        this.guid = firstNonNull(otherEncass.guid, this.guid);
-        this.setName(firstNonNull(otherEncass.getName(), this.getName()));
-        this.setId(firstNonNull(otherEncass.getId(), this.getId()));
-        this.properties.putAll(firstNonNull(otherEncass.properties, Collections.emptyMap()));
-        this.policy = firstNonNull(otherEncass.policy, this.policy);
-        this.path = firstNonNull(otherEncass.path, this.path);
-        this.arguments = firstNonNull(firstNonNull(otherEncass.arguments, Collections.emptySet()));
-        this.results = firstNonNull(firstNonNull(otherEncass.results, Collections.emptySet()));
-        this.policyId = firstNonNull(otherEncass.policyId, this.policyId);
-        this.annotations.addAll(firstNonNull(otherEncass.annotations, Collections.emptySet()));
-        return this;
     }
 
     @Override

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -14,6 +14,7 @@ import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
@@ -23,9 +24,11 @@ import java.io.File;
 import java.util.*;
 
 import static com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile.FileType.JSON_YAML;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 import static java.util.stream.Collectors.toCollection;
 
+@JsonInclude(NON_NULL)
 @Named("ENCAPSULATED_ASSERTION")
 @ConfigurationFile(name = "encass", type = JSON_YAML)
 @EnvironmentType("ENCAPSULATED_ASSERTION")
@@ -49,7 +52,7 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
 
     /* Set to true if any Parent (Policy or Encass) in hierarchy is annotated with @shared */
     @JsonIgnore
-    private boolean parentEntityShared;
+    private boolean isParentEntityShared;
 
     public Encass() { }
 
@@ -123,11 +126,11 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     }
 
     public boolean isParentEntityShared() {
-        return parentEntityShared;
+        return isParentEntityShared;
     }
 
     public void setParentEntityShared(boolean parentEntityShared) {
-        this.parentEntityShared = parentEntityShared;
+        isParentEntityShared = parentEntityShared;
     }
 
     Encass merge(Encass otherEncass) {
@@ -154,6 +157,48 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
     @Override
     public void preWrite(File configFolder, DocumentFileUtils documentFileUtils) {
         sortArgumentsAndResults();
+    }
+
+    @JsonIgnore
+    @Override
+    public Metadata getMetadata() {
+        return new Metadata() {
+            @Override
+            public String getType() {
+                return EntityTypes.ENCAPSULATED_ASSERTION_TYPE;
+            }
+
+            @Override
+            public String getName() {
+                return Encass.this.getName();
+            }
+
+            @Override
+            public String getId() {
+                AnnotatedEntity annotatedEntity = getAnnotatedEntity();
+                if (annotatedEntity != null && StringUtils.isNotBlank(annotatedEntity.getId())) {
+                    return annotatedEntity.getId();
+                }
+                return Encass.this.getId();
+            }
+
+            @Override
+            public String getGuid() {
+                AnnotatedEntity annotatedEntity = getAnnotatedEntity();
+                if (annotatedEntity != null && StringUtils.isNotBlank(annotatedEntity.getGuid())) {
+                    return annotatedEntity.getGuid();
+                }
+                return Encass.this.getGuid();
+            }
+
+            public Set<EncassArgument> getArguments() {
+                return Encass.this.getArguments();
+            }
+
+            public Set<EncassResult> getResults() {
+                return Encass.this.getResults();
+            }
+        };
     }
 
     @VisibleForTesting

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GatewayEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GatewayEntity.java
@@ -66,4 +66,9 @@ public class GatewayEntity {
     public void preWrite(File configFolder, DocumentFileUtils documentFileUtils) {
         //
     }
+
+    public Metadata getMetadata() {
+        return null;
+    }
+
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GatewayEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GatewayEntity.java
@@ -66,9 +66,4 @@ public class GatewayEntity {
     public void preWrite(File configFolder, DocumentFileUtils documentFileUtils) {
         //
     }
-
-    public Metadata getMetadata() {
-        return null;
-    }
-
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
@@ -58,7 +58,7 @@ public class Policy extends Folderable implements AnnotableEntity {
     private boolean hasRouting;
     /* Set to true if any Parent (Policy or Encass) in hierarchy is annotated with @shared */
     @JsonIgnore
-    private boolean parentEntityShared;
+    private boolean isParentEntityShared;
 
     public Policy() {
     }
@@ -155,11 +155,11 @@ public class Policy extends Folderable implements AnnotableEntity {
     }
 
     public boolean isParentEntityShared() {
-        return parentEntityShared;
+        return isParentEntityShared;
     }
 
     public void setParentEntityShared(boolean parentEntityShared) {
-        this.parentEntityShared = parentEntityShared;
+        isParentEntityShared = parentEntityShared;
     }
 
     Policy merge(Policy otherPolicy) {
@@ -262,6 +262,11 @@ public class Policy extends Folderable implements AnnotableEntity {
     public AnnotatedEntity getAnnotatedEntity() {
         if (annotatedEntity == null && annotations != null) {
             annotatedEntity = createAnnotatedEntity();
+            if (StringUtils.isBlank(annotatedEntity.getDescription())) {
+                annotatedEntity.setDescription("");
+            }
+            annotatedEntity.setPolicyName(getName());
+            annotatedEntity.setEntityName(getName());
         }
         return annotatedEntity;
     }
@@ -274,6 +279,33 @@ public class Policy extends Folderable implements AnnotableEntity {
     @Override
     public String getEntityType(){
         return EntityTypes.POLICY_TYPE;
+    }
+
+    @JsonIgnore
+    @Override
+    public Metadata getMetadata() {
+        return new Metadata() {
+            @Override
+            public String getType() {
+                return EntityTypes.POLICY_TYPE;
+            }
+
+            @Override
+            public String getName() {
+                return Policy.this.getName();
+            }
+
+            @Override
+            public String getId() {
+                return Policy.this.getId();
+            }
+
+            @Override
+            public String getGuid() {
+                return Policy.this.getGuid();
+            }
+
+        };
     }
 
     @Override

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
@@ -73,6 +73,7 @@ public class Policy extends Folderable implements AnnotableEntity {
         setParentFolder(builder.parentFolderId != null ? new Folder(builder.parentFolderId, null) : null);
     }
 
+    // Copy constructor
     public Policy(Policy otherPolicy) {
         merge(otherPolicy);
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
@@ -58,7 +58,7 @@ public class Policy extends Folderable implements AnnotableEntity {
     private boolean hasRouting;
     /* Set to true if any Parent (Policy or Encass) in hierarchy is annotated with @shared */
     @JsonIgnore
-    private boolean isParentEntityShared;
+    private boolean parentEntityShared;
 
     public Policy() {
     }
@@ -155,11 +155,11 @@ public class Policy extends Folderable implements AnnotableEntity {
     }
 
     public boolean isParentEntityShared() {
-        return isParentEntityShared;
+        return parentEntityShared;
     }
 
     public void setParentEntityShared(boolean parentEntityShared) {
-        isParentEntityShared = parentEntityShared;
+        this.parentEntityShared = parentEntityShared;
     }
 
     Policy merge(Policy otherPolicy) {
@@ -262,11 +262,6 @@ public class Policy extends Folderable implements AnnotableEntity {
     public AnnotatedEntity getAnnotatedEntity() {
         if (annotatedEntity == null && annotations != null) {
             annotatedEntity = createAnnotatedEntity();
-            if (StringUtils.isBlank(annotatedEntity.getDescription())) {
-                annotatedEntity.setDescription("");
-            }
-            annotatedEntity.setPolicyName(getName());
-            annotatedEntity.setEntityName(getName());
         }
         return annotatedEntity;
     }
@@ -279,33 +274,6 @@ public class Policy extends Folderable implements AnnotableEntity {
     @Override
     public String getEntityType(){
         return EntityTypes.POLICY_TYPE;
-    }
-
-    @JsonIgnore
-    @Override
-    public Metadata getMetadata() {
-        return new Metadata() {
-            @Override
-            public String getType() {
-                return EntityTypes.POLICY_TYPE;
-            }
-
-            @Override
-            public String getName() {
-                return Policy.this.getName();
-            }
-
-            @Override
-            public String getId() {
-                return Policy.this.getId();
-            }
-
-            @Override
-            public String getGuid() {
-                return Policy.this.getGuid();
-            }
-
-        };
     }
 
     @Override

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
@@ -58,7 +58,7 @@ public class Policy extends Folderable implements AnnotableEntity {
     private boolean hasRouting;
     /* Set to true if any Parent (Policy or Encass) in hierarchy is annotated with @shared */
     @JsonIgnore
-    private boolean isParentEntityShared;
+    private boolean parentEntityShared;
 
     public Policy() {
     }
@@ -155,11 +155,11 @@ public class Policy extends Folderable implements AnnotableEntity {
     }
 
     public boolean isParentEntityShared() {
-        return isParentEntityShared;
+        return parentEntityShared;
     }
 
     public void setParentEntityShared(boolean parentEntityShared) {
-        isParentEntityShared = parentEntityShared;
+        this.parentEntityShared = parentEntityShared;
     }
 
     Policy merge(Policy otherPolicy) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
@@ -22,9 +22,7 @@ import org.w3c.dom.Element;
 
 import javax.inject.Named;
 import java.io.File;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
@@ -44,7 +42,7 @@ public class Policy extends Folderable implements AnnotableEntity {
     @JsonIgnore
     private Element policyDocument;
     @JsonIgnore
-    private Set<Annotation> annotations;
+    private Set<Annotation> annotations = new HashSet<>();
     @JsonIgnore
     private final Set<Policy> dependencies = new HashSet<>();
     private String tag;
@@ -53,11 +51,14 @@ public class Policy extends Folderable implements AnnotableEntity {
     @JsonIgnore
     private PolicyType policyType;
     @JsonIgnore
-    private Set<Dependency> usedEntities;
+    private Set<Dependency> usedEntities = new LinkedHashSet<>();
     @JsonIgnore
     private AnnotatedEntity<? extends GatewayEntity> annotatedEntity;
 
     private boolean hasRouting;
+    /* Set to true if any Parent (Policy or Encass) in hierarchy is annotated with @shared */
+    @JsonIgnore
+    private boolean isParentEntityShared;
 
     public Policy() {
     }
@@ -70,6 +71,10 @@ public class Policy extends Folderable implements AnnotableEntity {
         this.tag = builder.tag;
         this.subtag = builder.subtag;
         setParentFolder(builder.parentFolderId != null ? new Folder(builder.parentFolderId, null) : null);
+    }
+
+    public Policy(Policy otherPolicy) {
+        merge(otherPolicy);
     }
 
     public Set<Dependency> getUsedEntities() {
@@ -149,17 +154,29 @@ public class Policy extends Folderable implements AnnotableEntity {
         this.hasRouting = hasRouting;
     }
 
+    public boolean isParentEntityShared() {
+        return isParentEntityShared;
+    }
+
+    public void setParentEntityShared(boolean parentEntityShared) {
+        isParentEntityShared = parentEntityShared;
+    }
+
     Policy merge(Policy otherPolicy) {
         this.policyXML = firstNonNull(otherPolicy.policyXML, this.policyXML);
+        this.setPath(firstNonNull(otherPolicy.getPath(), this.getPath()));
         this.setName(firstNonNull(otherPolicy.getName(), this.getName()));
         this.setParentFolder(firstNonNull(otherPolicy.getParentFolder(), this.getParentFolder()));
         this.guid = firstNonNull(otherPolicy.guid, this.guid);
         this.policyDocument = firstNonNull(otherPolicy.policyDocument, this.policyDocument);
-        this.dependencies.addAll(otherPolicy.dependencies);
+        this.dependencies.addAll(firstNonNull(otherPolicy.dependencies, Collections.emptySet()));
         this.setId(firstNonNull(otherPolicy.getId(), this.getId()));
         this.tag = firstNonNull(otherPolicy.tag, this.tag);
+        this.subtag = firstNonNull(otherPolicy.subtag, this.subtag);
         this.policyType = firstNonNull(otherPolicy.policyType, this.policyType);
         this.hasRouting = otherPolicy.hasRouting || this.hasRouting;
+        this.usedEntities.addAll(firstNonNull(otherPolicy.usedEntities, Collections.emptySet()));
+        this.annotations.addAll(firstNonNull(otherPolicy.annotations, Collections.emptySet()));
         return this;
     }
 
@@ -291,4 +308,20 @@ public class Policy extends Folderable implements AnnotableEntity {
         };
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Policy)) {
+            return false;
+        }
+        Policy policy = (Policy) o;
+        return Objects.equals(getPath(), policy.getPath());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getPath());
+    }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Policy.java
@@ -263,11 +263,6 @@ public class Policy extends Folderable implements AnnotableEntity {
     public AnnotatedEntity getAnnotatedEntity() {
         if (annotatedEntity == null && annotations != null) {
             annotatedEntity = createAnnotatedEntity();
-            if (StringUtils.isBlank(annotatedEntity.getDescription())) {
-                annotatedEntity.setDescription("");
-            }
-            annotatedEntity.setPolicyName(getName());
-            annotatedEntity.setEntityName(getName());
         }
         return annotatedEntity;
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Service.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Service.java
@@ -189,47 +189,6 @@ public class Service extends Folderable implements AnnotableEntity {
         return annotatedEntity;
     }
 
-    @JsonIgnore
-    @Override
-    public Metadata getMetadata() {
-        return new Metadata() {
-            public String getType() {
-                return EntityTypes.SERVICE_TYPE;
-            }
-
-            @Override
-            public String getName() {
-                return Service.this.getName();
-            }
-
-            @Override
-            public String getId() {
-                AnnotatedEntity annotatedEntity = getAnnotatedEntity();
-                if (annotatedEntity != null && annotatedEntity.getId() != null) {
-                    return annotatedEntity.getId();
-                }
-                return Service.this.getId();
-            }
-
-            @Override
-            public String getGuid() {
-                AnnotatedEntity annotatedEntity = getAnnotatedEntity();
-                if (annotatedEntity != null && annotatedEntity.getGuid() != null) {
-                    return annotatedEntity.getGuid();
-                }
-                return Service.this.getGuid();
-            }
-
-            public String getUri() {
-                return Service.this.getUrl();
-            }
-
-            public boolean isSoap() {
-                return  Service.this.getSoapResources() != null && StringUtils.isNotBlank(Service.this.getWsdlRootUrl());
-            }
-        };
-    }
-
     @Override
     public String getEntityType(){
         return EntityTypes.SERVICE_TYPE;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Service.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Service.java
@@ -189,6 +189,47 @@ public class Service extends Folderable implements AnnotableEntity {
         return annotatedEntity;
     }
 
+    @JsonIgnore
+    @Override
+    public Metadata getMetadata() {
+        return new Metadata() {
+            public String getType() {
+                return EntityTypes.SERVICE_TYPE;
+            }
+
+            @Override
+            public String getName() {
+                return Service.this.getName();
+            }
+
+            @Override
+            public String getId() {
+                AnnotatedEntity annotatedEntity = getAnnotatedEntity();
+                if (annotatedEntity != null && annotatedEntity.getId() != null) {
+                    return annotatedEntity.getId();
+                }
+                return Service.this.getId();
+            }
+
+            @Override
+            public String getGuid() {
+                AnnotatedEntity annotatedEntity = getAnnotatedEntity();
+                if (annotatedEntity != null && annotatedEntity.getGuid() != null) {
+                    return annotatedEntity.getGuid();
+                }
+                return Service.this.getGuid();
+            }
+
+            public String getUri() {
+                return Service.this.getUrl();
+            }
+
+            public boolean isSoap() {
+                return  Service.this.getSoapResources() != null && StringUtils.isNotBlank(Service.this.getWsdlRootUrl());
+            }
+        };
+    }
+
     @Override
     public String getEntityType(){
         return EntityTypes.SERVICE_TYPE;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotableEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotableEntity.java
@@ -2,6 +2,7 @@ package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Annotation;
 import com.ca.apim.gateway.cagatewayconfig.beans.GatewayEntity;
+import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.Set;
@@ -54,9 +55,12 @@ public interface AnnotableEntity {
                 } else if(BUNDLE_HINTS.equalsIgnoreCase(annotation.getType())) {
                     annotatedEntity.setId(annotation.getId());
                     annotatedEntity.setGuid(annotation.getGuid());
-                    annotatedEntity.setTags(annotation.getTags());
-                    annotatedEntity.setBundleName(annotation.getName());
-                    annotatedEntity.setDescription(annotation.getDescription());
+                    if (this.getEntityType().equals(EntityTypes.SERVICE_TYPE)
+                        || this.getEntityType().equals(EntityTypes.ENCAPSULATED_ASSERTION_TYPE)) {
+                        annotatedEntity.setTags(annotation.getTags());
+                        annotatedEntity.setBundleName(annotation.getName());
+                        annotatedEntity.setDescription(annotation.getDescription());
+                    }
                 }
             });
             return annotatedEntity;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotableEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotableEntity.java
@@ -2,7 +2,6 @@ package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Annotation;
 import com.ca.apim.gateway.cagatewayconfig.beans.GatewayEntity;
-import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.Set;
@@ -55,12 +54,9 @@ public interface AnnotableEntity {
                 } else if(BUNDLE_HINTS.equalsIgnoreCase(annotation.getType())) {
                     annotatedEntity.setId(annotation.getId());
                     annotatedEntity.setGuid(annotation.getGuid());
-                    if (this.getEntityType().equals(EntityTypes.SERVICE_TYPE)
-                        || this.getEntityType().equals(EntityTypes.ENCAPSULATED_ASSERTION_TYPE)) {
-                        annotatedEntity.setTags(annotation.getTags());
-                        annotatedEntity.setBundleName(annotation.getName());
-                        annotatedEntity.setDescription(annotation.getDescription());
-                    }
+                    annotatedEntity.setTags(annotation.getTags());
+                    annotatedEntity.setBundleName(annotation.getName());
+                    annotatedEntity.setDescription(annotation.getDescription());
                 }
             });
             return annotatedEntity;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedBundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedBundle.java
@@ -58,9 +58,10 @@ public class AnnotatedBundle extends Bundle {
         return dependentBundles;
     }
 
-    public String getNamespace(final EntityBuilder.BundleType bundleType) {
-        if(EntityBuilder.BundleType.ENVIRONMENT == bundleType) {
-            return super.getNamespace(bundleType);
+
+    public String getNamespace(final EntityBuilder.BundleType bundleType, boolean isShared) {
+        if (isShared || EntityBuilder.BundleType.ENVIRONMENT == bundleType) {
+            return super.getNamespace(bundleType, isShared);
         }
 
         StringBuilder namespace = new StringBuilder();

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/AnnotatedEntity.java
@@ -85,12 +85,7 @@ public class AnnotatedEntity<T> {
     }
 
     public boolean isBundle() {
-
         return entity instanceof AnnotableEntity && ((AnnotableEntity) entity).isBundle();
-    }
-
-    public boolean isShared() {
-        return entity instanceof AnnotableEntity && ((AnnotableEntity) entity).isShared();
     }
 
     public boolean isRedeployable() {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
@@ -13,7 +13,10 @@ import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.*;
@@ -38,8 +41,8 @@ public class BundleMetadataBuilder {
      * @param projectInfo       Gradle Project info containing Gradle project name, groupName and version
      * @return Full bundle or Annotated bundle metadata
      */
-    public BundleMetadata build(final AnnotatedBundle annotatedBundle, final Bundle bundle,
-                                final List<Entity> dependentEntities, ProjectInfo projectInfo) {
+    public BundleMetadata build(final AnnotatedBundle annotatedBundle, final Bundle bundle, final List<Entity> dependentEntities,
+                                ProjectInfo projectInfo) {
         if (annotatedBundle != null && annotatedBundle.getAnnotatedEntity() != null) {
             AnnotatedEntity<? extends GatewayEntity> annotatedEntity = annotatedBundle.getAnnotatedEntity();
             final String bundleName = annotatedBundle.getBundleName();
@@ -48,8 +51,7 @@ public class BundleMetadataBuilder {
                 name =  bundleName.substring(0, bundleName.indexOf(projectInfo.getVersion()) - 1);
             }
 
-            BundleMetadata.Builder builder = new BundleMetadata.Builder(annotatedEntity.getEntityType(), name,
-                    projectInfo.getName(), projectInfo.getGroupName(), projectInfo.getVersion());
+            BundleMetadata.Builder builder = new BundleMetadata.Builder(annotatedEntity.getEntityType(), name, projectInfo.getName(), projectInfo.getGroupName(), projectInfo.getVersion());
             builder.description(annotatedEntity.getDescription());
             final Collection<Metadata> referencedEntities = getEnvironmentDependenciesMetadata(dependentEntities);
             builder.referencedEntities(referencedEntities);
@@ -63,9 +65,7 @@ public class BundleMetadataBuilder {
             builder.hasRouting(hasRoutingAssertion(dependentEntities));
 
             final List<Metadata> definedEntities = new ArrayList<>();
-            Optional<Entity> definedEntity =
-                    dependentEntities.parallelStream().filter(e -> annotatedEntity.getEntity().getName().equals(e.getOriginalName())).findAny();
-            definedEntity.ifPresent(e -> definedEntities.add(e.getMetadata()));
+            definedEntities.add(annotatedEntity.getEntity().getMetadata());
 
             return builder.definedEntities(definedEntities).build();
         } else {
@@ -133,7 +133,7 @@ public class BundleMetadataBuilder {
 
     private Collection<Metadata> getDefinedEntitiesMetadata(final List<Entity> definedEntities) {
         return definedEntities.stream().filter(FILTER_NON_ENV_ENTITIES_EXCLUDING_FOLDER)
-                .map(Entity::getMetadata).collect(Collectors.toList());
+                .map(e -> ((GatewayEntity)e.getGatewayEntity()).getMetadata()).collect(Collectors.toList());
     }
 
     private boolean isBundleContainsSharedEntity (final AnnotatedBundle annotatedBundle) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
@@ -137,7 +137,8 @@ public class BundleMetadataBuilder {
     }
 
     private boolean isBundleContainsSharedEntity (final AnnotatedBundle annotatedBundle) {
-        return annotatedBundle.getAnnotatedEntity().isShared();
+        return annotatedBundle.getEncasses().values().stream().anyMatch(Encass::isParentEntityShared)
+               || annotatedBundle.getPolicies().values().stream().anyMatch(Policy::isParentEntityShared);
     }
 
     private boolean hasRoutingAssertion(final List<Entity> dependentEntities) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
@@ -13,10 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.*;
@@ -41,8 +38,8 @@ public class BundleMetadataBuilder {
      * @param projectInfo       Gradle Project info containing Gradle project name, groupName and version
      * @return Full bundle or Annotated bundle metadata
      */
-    public BundleMetadata build(final AnnotatedBundle annotatedBundle, final Bundle bundle, final List<Entity> dependentEntities,
-                                ProjectInfo projectInfo) {
+    public BundleMetadata build(final AnnotatedBundle annotatedBundle, final Bundle bundle,
+                                final List<Entity> dependentEntities, ProjectInfo projectInfo) {
         if (annotatedBundle != null && annotatedBundle.getAnnotatedEntity() != null) {
             AnnotatedEntity<? extends GatewayEntity> annotatedEntity = annotatedBundle.getAnnotatedEntity();
             final String bundleName = annotatedBundle.getBundleName();
@@ -51,7 +48,8 @@ public class BundleMetadataBuilder {
                 name =  bundleName.substring(0, bundleName.indexOf(projectInfo.getVersion()) - 1);
             }
 
-            BundleMetadata.Builder builder = new BundleMetadata.Builder(annotatedEntity.getEntityType(), name, projectInfo.getName(), projectInfo.getGroupName(), projectInfo.getVersion());
+            BundleMetadata.Builder builder = new BundleMetadata.Builder(annotatedEntity.getEntityType(), name,
+                    projectInfo.getName(), projectInfo.getGroupName(), projectInfo.getVersion());
             builder.description(annotatedEntity.getDescription());
             final Collection<Metadata> referencedEntities = getEnvironmentDependenciesMetadata(dependentEntities);
             builder.referencedEntities(referencedEntities);
@@ -65,7 +63,9 @@ public class BundleMetadataBuilder {
             builder.hasRouting(hasRoutingAssertion(dependentEntities));
 
             final List<Metadata> definedEntities = new ArrayList<>();
-            definedEntities.add(annotatedEntity.getEntity().getMetadata());
+            Optional<Entity> definedEntity =
+                    dependentEntities.parallelStream().filter(e -> annotatedEntity.getEntity().getName().equals(e.getOriginalName())).findAny();
+            definedEntity.ifPresent(e -> definedEntities.add(e.getMetadata()));
 
             return builder.definedEntities(definedEntities).build();
         } else {
@@ -133,7 +133,7 @@ public class BundleMetadataBuilder {
 
     private Collection<Metadata> getDefinedEntitiesMetadata(final List<Entity> definedEntities) {
         return definedEntities.stream().filter(FILTER_NON_ENV_ENTITIES_EXCLUDING_FOLDER)
-                .map(e -> ((GatewayEntity)e.getGatewayEntity()).getMetadata()).collect(Collectors.toList());
+                .map(Entity::getMetadata).collect(Collectors.toList());
     }
 
     private boolean isBundleContainsSharedEntity (final AnnotatedBundle annotatedBundle) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncapsulatedAssertionBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncapsulatedAssertionBuilder.java
@@ -45,7 +45,12 @@ public class EncapsulatedAssertionBuilder implements PolicyAssertionBuilder {
 
     private Encass getEncass(Bundle bundle, String name, AnnotatedBundle annotatedBundle) {
         LOGGER.log(Level.FINE, "Looking for referenced encass: {0}", name);
-        final AtomicReference<Encass> referenceEncass = new AtomicReference<>(bundle.getEncasses().get(name));
+        final AtomicReference<Encass> referenceEncass;
+        if (annotatedBundle != null) {
+            referenceEncass = new AtomicReference<>(annotatedBundle.getEncasses().get(name));
+        } else {
+            referenceEncass = new AtomicReference<>(bundle.getEncasses().get(name));
+        }
 
         if (referenceEncass.get() == null) {
             //check the dependency in the given dependent bundle
@@ -113,7 +118,7 @@ public class EncapsulatedAssertionBuilder implements PolicyAssertionBuilder {
         AnnotatedEntity annotatedEntity = annotatedBundle != null ? annotatedBundle.getAnnotatedEntity() : null;
         if (encass != null && !encass.isExcluded() && annotatedEntity != null) {
             AnnotatedEntity annotatedEncassEntity = encass.getAnnotatedEntity();
-            if (annotatedEntity.isShared()) {
+            if (encass.isParentEntityShared()) {
                 if (annotatedEncassEntity != null) {
                     if (annotatedEncassEntity.getGuid() != null) {
                         if (IdValidator.isValidGuid(annotatedEncassEntity.getGuid())) {
@@ -135,8 +140,8 @@ public class EncapsulatedAssertionBuilder implements PolicyAssertionBuilder {
                 encassGuid = idGenerator.generateGuid();
                 encass.setGuid(encassGuid);
                 encass.setId(idGenerator.generate());
-                encassName = annotatedBundle.applyUniqueName(encassName, EntityBuilder.BundleType.DEPLOYMENT);
             }
+            encassName = annotatedBundle.applyUniqueName(encassName, EntityBuilder.BundleType.DEPLOYMENT, encass.isParentEntityShared());
         }
         Element encapsulatedAssertionConfigNameElement = createElementWithAttribute(
                 policyBuilderContext.getPolicyDocument(),

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -155,10 +155,10 @@ public class EncassEntityBuilder implements EntityBuilder {
                     }
                 }
             } else {
-                encassName = annotatedBundle.applyUniqueName(name, BundleType.DEPLOYMENT);
                 //guid and id are regenerated in policy entity builder if this encass is referred by policy and it runs before this builder
                 //no need to regenerate id and guid
             }
+            encassName = annotatedBundle.applyUniqueName(name, BundleType.DEPLOYMENT, isShared);
         }
 
         Element encassAssertionElement = createElementWithAttributesAndChildren(

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -56,7 +56,7 @@ public class EncassEntityBuilder implements EntityBuilder {
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
         if (bundle instanceof AnnotatedBundle) {
             AnnotatedBundle annotatedBundle = ((AnnotatedBundle) bundle);
-            Map<String, Encass> map = Optional.ofNullable(bundle.getEncasses()).orElse(Collections.emptyMap());
+            Map<String, Encass> map = Optional.ofNullable(annotatedBundle.getEncasses()).orElse(Collections.emptyMap());
             return buildEntities(map, annotatedBundle, annotatedBundle.getFullBundle(), bundleType, document);
         } else {
             return buildEntities(bundle.getEncasses(), null, bundle, bundleType, document);
@@ -81,7 +81,12 @@ public class EncassEntityBuilder implements EntityBuilder {
     }
 
     private String getPolicyId(String policyWithPath, Bundle bundle, AnnotatedBundle annotatedBundle) {
-        final AtomicReference<Policy> includedPolicy = new AtomicReference<>(bundle.getPolicies().get(policyWithPath));
+        final AtomicReference<Policy> includedPolicy;
+        if (annotatedBundle != null) {
+            includedPolicy = new AtomicReference<>(annotatedBundle.getPolicies().get(policyWithPath));
+        } else {
+            includedPolicy = new AtomicReference<>(bundle.getPolicies().get(policyWithPath));
+        }
         if (includedPolicy.get() == null) {
             //check policy dependency in bundle dependencies
             Set<Bundle> dependencies = bundle.getDependencies();
@@ -134,7 +139,7 @@ public class EncassEntityBuilder implements EntityBuilder {
         boolean isShared = false;
         if (annotatedEntity != null) {
             isRedeployableBundle = annotatedEntity.isRedeployable();
-            isShared = annotatedEntity.isShared();
+            isShared = encass.isParentEntityShared();
             annotatedEncassEntity = encass.getAnnotatedEntity();
             if (isShared) {
                 //use the id and guid defined at bundle-hints annotation (if its annotated bundle)

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -129,7 +129,7 @@ public class EncassEntityBuilder implements EntityBuilder {
 
     private Entity buildEncassEntity(AnnotatedBundle annotatedBundle, Bundle bundle, String name, Encass encass, Document document) {
         String policyId = getPolicyId(encass.getPolicy(), bundle, annotatedBundle);
-        String encassName = name;
+        String uniqueEncassName = name;
         String guid = encass.getGuid();
         String id = encass.getId();
         AnnotatedEntity annotatedEncassEntity = null;
@@ -163,14 +163,14 @@ public class EncassEntityBuilder implements EntityBuilder {
                 //guid and id are regenerated in policy entity builder if this encass is referred by policy and it runs before this builder
                 //no need to regenerate id and guid
             }
-            encassName = annotatedBundle.applyUniqueName(name, BundleType.DEPLOYMENT, isShared);
+            uniqueEncassName = annotatedBundle.applyUniqueName(name, BundleType.DEPLOYMENT, isShared);
         }
-
+        encass.setUniqueEntityName(uniqueEncassName);
         Element encassAssertionElement = createElementWithAttributesAndChildren(
                 document,
                 ENCAPSULATED_ASSERTION,
                 ImmutableMap.of(ATTRIBUTE_ID, id),
-                createElementWithTextContent(document, NAME, encassName),
+                createElementWithTextContent(document, NAME, uniqueEncassName),
                 createElementWithTextContent(document, GUID, guid),
                 createElementWithAttribute(document, POLICY_REFERENCE, ATTRIBUTE_ID, policyId),
                 buildArguments(encass, document),
@@ -180,7 +180,7 @@ public class EncassEntityBuilder implements EntityBuilder {
         final Map<String, Object> properties = Optional.ofNullable(encass.getProperties()).orElse(new HashMap<>());
         properties.putIfAbsent(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
         buildAndAppendPropertiesElement(properties, document, encassAssertionElement);
-        Entity entity = getEntityWithNameMapping(ENCAPSULATED_ASSERTION_TYPE, name, encassName, id, encassAssertionElement, guid, encass);
+        Entity entity = getEntityWithNameMapping(ENCAPSULATED_ASSERTION_TYPE, name, uniqueEncassName, id, encassAssertionElement, guid, encass);
 
         if (isRedeployableBundle || !isShared) {
             entity.setMappingAction(MappingActions.NEW_OR_UPDATE);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IncludeAssertionBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IncludeAssertionBuilder.java
@@ -35,8 +35,12 @@ public class IncludeAssertionBuilder implements PolicyAssertionBuilder {
         }
         final String policyPath = policyGuidElement.getAttribute(POLICY_PATH);
         LOGGER.log(Level.FINE, "Looking for referenced policy include: {0}", policyPath);
-
-        final AtomicReference<Policy> includedPolicy = new AtomicReference<>(bundle.getPolicies().get(policyPath));
+        final AtomicReference<Policy> includedPolicy;
+        if (annotatedBundle != null) {
+            includedPolicy = new AtomicReference<>(annotatedBundle.getPolicies().get(policyPath));
+        } else {
+            includedPolicy = new AtomicReference<>(bundle.getPolicies().get(policyPath));
+        }
         if (includedPolicy.get() != null) {
             policy.getDependencies().add(includedPolicy.get());
         } else {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -77,7 +77,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
             Policy policyEntity = (Policy) policy;
             if (annotatedEntity != null) {
                 AnnotatedEntity annotatedPolicyEntity = policyEntity.getAnnotatedEntity();
-                if (annotatedEntity.isShared()) {
+                if (policyEntity.isParentEntityShared()) {
                     if (annotatedPolicyEntity != null) {
                         if (annotatedPolicyEntity.getId() != null) {
                             if (IdValidator.isValidGoid(annotatedPolicyEntity.getId())) {
@@ -144,7 +144,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
         String policyName = policy.getName();
         AnnotatedEntity annotatedEntity = annotatedBundle != null ? annotatedBundle.getAnnotatedEntity() : null;
         if (annotatedEntity != null) {
-            policyName = annotatedBundle.applyUniqueName(policy.getName(), BundleType.DEPLOYMENT, annotatedEntity.isShared());
+            policyName = annotatedBundle.applyUniqueName(policy.getName(), BundleType.DEPLOYMENT, policy.isParentEntityShared());
         }
 
         PolicyBuilderContext policyBuilderContext = new PolicyBuilderContext(policyName, policyDocument, bundle, idGenerator);
@@ -198,13 +198,9 @@ public class PolicyEntityBuilder implements EntityBuilder {
         policyNameWithPath = CharacterBlacklistUtil.decodePath(policyNameWithPath);
         AnnotatedEntity annotatedEntity = annotatedBundle != null ? annotatedBundle.getAnnotatedEntity() : null;
         boolean isRedeployableBundle = false;
-        boolean isShared = false;
         if (annotatedEntity != null) {
             isRedeployableBundle = annotatedEntity.isRedeployable();
-            isShared = annotatedEntity.isShared();
-        }
-        if (annotatedBundle != null) {
-            policyName = annotatedBundle.applyUniqueName(policyName, BundleType.DEPLOYMENT, isShared);
+            policyName = annotatedBundle.applyUniqueName(policyName, BundleType.DEPLOYMENT, policy.isParentEntityShared());
             policyNameWithPath = PathUtils.extractPath(policyNameWithPath) + policyName;
         }
 
@@ -247,7 +243,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
         policyElement.appendChild(resourcesElement);
         Entity entity = EntityBuilderHelper.getEntityWithPathMapping(EntityTypes.POLICY_TYPE,
                 policy.getPath(), policyNameWithPath, policy.getId(), policyElement, policy.isHasRouting(), policy);
-        if (isRedeployableBundle || !isShared) {
+        if (isRedeployableBundle || !policy.isParentEntityShared()) {
             entity.setMappingAction(MappingActions.NEW_OR_UPDATE);
         } else {
             entity.setMappingAction(MappingActions.NEW_OR_EXISTING);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -141,16 +141,10 @@ public class PolicyEntityBuilder implements EntityBuilder {
 
     private void preparePolicy(Policy policy, Bundle bundle, AnnotatedBundle annotatedBundle) {
         Document policyDocument = loadPolicyDocument(policy);
-        final String policyName;
+        String policyName = policy.getName();
         AnnotatedEntity annotatedEntity = annotatedBundle != null ? annotatedBundle.getAnnotatedEntity() : null;
         if (annotatedEntity != null) {
-            if (annotatedEntity.isShared()) {
-                policyName = policy.getName();
-            } else {
-                policyName = annotatedBundle.applyUniqueName(policy.getName(), BundleType.DEPLOYMENT);
-            }
-        } else {
-            policyName = policy.getName();
+            policyName = annotatedBundle.applyUniqueName(policy.getName(), BundleType.DEPLOYMENT, annotatedEntity.isShared());
         }
 
         PolicyBuilderContext policyBuilderContext = new PolicyBuilderContext(policyName, policyDocument, bundle, idGenerator);
@@ -210,10 +204,8 @@ public class PolicyEntityBuilder implements EntityBuilder {
             isShared = annotatedEntity.isShared();
         }
         if (annotatedBundle != null) {
-            if (!isShared) {
-                policyName = annotatedBundle.applyUniqueName(policyName, BundleType.DEPLOYMENT);
-                policyNameWithPath = PathUtils.extractPath(policyNameWithPath) + policyName;
-            }
+            policyName = annotatedBundle.applyUniqueName(policyName, BundleType.DEPLOYMENT, isShared);
+            policyNameWithPath = PathUtils.extractPath(policyNameWithPath) + policyName;
         }
 
         PolicyTags policyTags = getPolicyTags(policy, bundle);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
@@ -72,10 +72,8 @@ public class ServiceEntityBuilder implements EntityBuilder {
         String uniqueName = baseName;
         String uniqueServicePath = servicePath;
         boolean isRedeployableBundle = false;
-        boolean isShared = false;
         if (annotatedEntity != null) {
             isRedeployableBundle = annotatedEntity.isRedeployable();
-            isShared = annotatedEntity.isShared();
             uniqueName = bundle.applyUniqueName(baseName, BundleType.DEPLOYMENT);
             uniqueServicePath = basePath + uniqueName;
         }
@@ -159,7 +157,7 @@ public class ServiceEntityBuilder implements EntityBuilder {
         serviceElement.appendChild(resourcesElement);
         Entity entity = EntityBuilderHelper.getEntityWithPathMapping(SERVICE_TYPE, uniqueServicePath, uniqueServicePath, id,
                 serviceElement, false, service);
-        if (isRedeployableBundle || !isShared) {
+        if (isRedeployableBundle) {
             entity.setMappingAction(MappingActions.NEW_OR_UPDATE);
         } else {
             entity.setMappingAction(MappingActions.NEW_OR_EXISTING);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/EntityBundleLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/EntityBundleLoader.java
@@ -10,6 +10,7 @@ import com.ca.apim.gateway.cagatewayconfig.beans.*;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.*;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.file.JsonFileUtils;
+import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import org.w3c.dom.Document;
@@ -93,7 +94,8 @@ public class EntityBundleLoader {
 
     private Encass getEncassFromMetadata(final Metadata metadata) {
         Encass encass = new Encass();
-        encass.setName(metadata.getName());
+        encass.setUniqueEntityName(metadata.getName());
+        encass.setName(PathUtils.extractNameFromUniqueEntityName(metadata.getName()));
         encass.setId(metadata.getId());
         encass.setGuid(metadata.getGuid());
         Set<Annotation> annotations = new HashSet<>();

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/paths/PathUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/paths/PathUtils.java
@@ -6,6 +6,7 @@
 
 package com.ca.apim.gateway.cagatewayconfig.util.paths;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
@@ -49,5 +50,13 @@ public class PathUtils {
     public static String extractPath(String nameWithPath) {
         int index = nameWithPath.lastIndexOf(UNIX_PATH_SEPARATOR);
         return index > -1 ? nameWithPath.substring(0, index + 1) : "";
+    }
+
+    public static String extractNameFromUniqueEntityName(String uniqueName) {
+        String[] nameParts = StringUtils.split(uniqueName, "::");
+        if (nameParts.length >= 2) {
+            return nameParts[1];
+        }
+        return StringUtils.remove(uniqueName, "::");
     }
 }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
@@ -28,6 +28,7 @@ import java.util.*;
 import static com.ca.apim.gateway.cagatewayconfig.beans.Folder.ROOT_FOLDER;
 import static com.ca.apim.gateway.cagatewayconfig.beans.Folder.ROOT_FOLDER_NAME;
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleEntityBuilderTestHelper.*;
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.DEPLOYMENT;
 import static com.ca.apim.gateway.cagatewayconfig.util.TestUtils.createFolder;
 import static com.ca.apim.gateway.cagatewayconfig.util.TestUtils.createRoot;
 import static com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes.LISTEN_PORT_TYPE;
@@ -81,7 +82,7 @@ class BundleEntityBuilderTest {
         BundleEntityBuilder builder = new BundleEntityBuilder(singleton(new TestEntityBuilder()),
                 new BundleDocumentBuilder(), new BundleMetadataBuilder(ID_GENERATOR), entityTypeRegistry);
 
-        final Map<String, BundleArtifacts> element = builder.build(new Bundle(), BundleType.DEPLOYMENT,
+        final Map<String, BundleArtifacts> element = builder.build(new Bundle(), DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(element);
     }
@@ -116,12 +117,11 @@ class BundleEntityBuilderTest {
         Annotation bundleAnnotation = new Annotation(AnnotationType.BUNDLE);
         Annotation bundleHintsAnnotation = new Annotation(AnnotationType.BUNDLE_HINTS);
         bundleHintsAnnotation.setName(TEST_ENCASS_ANNOTATION_NAME);
-        Annotation sharedAnnotation = new Annotation(AnnotationType.SHARED);
         encassAnnotations.add(bundleAnnotation);
         encassAnnotations.add(bundleHintsAnnotation);
-        encassAnnotations.add(sharedAnnotation);
 
         Set<Annotation> depPolicyAnnotations = new HashSet<>();
+        Annotation sharedAnnotation = new Annotation(AnnotationType.SHARED);
         depPolicyAnnotations.add(sharedAnnotation);
 
         Policy depPolicy = buildTestPolicyWithAnnotation(TEST_DEP_ENCASS_POLICY, TEST_DEP_POLICY_ID, TEST_GUID, depPolicyAnnotations);
@@ -131,7 +131,6 @@ class BundleEntityBuilderTest {
         bundle.getEncasses().put(TEST_DEP_ENCASS, depEncass);
 
         Set<Dependency> usedEntities = new LinkedHashSet<>();
-        usedEntities.add(new Dependency(TEST_DEP_POLICY_ID, Policy.class, TEST_DEP_ENCASS_POLICY, EntityTypes.POLICY_TYPE));
         usedEntities.add(new Dependency(TEST_DEP_ENCASS_ID, Encass.class, TEST_DEP_ENCASS, EntityTypes.ENCAPSULATED_ASSERTION_TYPE));
         usedEntities.add(new Dependency(TEST_ENCASS_ID, Encass.class, TEST_ENCASS, EntityTypes.ENCAPSULATED_ASSERTION_TYPE));
 
@@ -147,8 +146,9 @@ class BundleEntityBuilderTest {
         entityBuilders.add(policyBuilder);
         entityBuilders.add(encassBuilder);
 
-        buildAndValidateAnnotatedBundle(bundle, entityBuilders, TEST_ENCASS_POLICY, NEW_OR_EXISTING, TEST_ENCASS, NEW_OR_EXISTING,
-                TEST_DEP_ENCASS_POLICY, NEW_OR_EXISTING, TEST_DEP_ENCASS, NEW_OR_EXISTING);
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, encass.getAnnotatedEntity(), projectInfo);
+        buildAndValidateAnnotatedBundle(bundle, annotatedBundle, entityBuilders, TEST_ENCASS_POLICY, NEW_OR_UPDATE,
+                TEST_ENCASS, NEW_OR_UPDATE, TEST_DEP_ENCASS_POLICY, NEW_OR_EXISTING, TEST_DEP_ENCASS, NEW_OR_UPDATE);
     }
 
     @Test
@@ -201,17 +201,20 @@ class BundleEntityBuilderTest {
         entityBuilders.add(policyBuilder);
         entityBuilders.add(encassBuilder);
 
-        buildAndValidateAnnotatedBundle(bundle, entityBuilders, TEST_ENCASS_POLICY, NEW_OR_UPDATE, TEST_ENCASS, NEW_OR_UPDATE,
-                TEST_DEP_ENCASS_POLICY, NEW_OR_UPDATE, TEST_DEP_ENCASS, NEW_OR_UPDATE);
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, encass.getAnnotatedEntity(), projectInfo);
+        buildAndValidateAnnotatedBundle(bundle, annotatedBundle, entityBuilders, TEST_ENCASS_POLICY, NEW_OR_UPDATE,
+                TEST_ENCASS, NEW_OR_UPDATE, TEST_DEP_ENCASS_POLICY, NEW_OR_UPDATE, TEST_DEP_ENCASS, NEW_OR_UPDATE);
 
     }
 
-    private static void buildAndValidateAnnotatedBundle(Bundle bundle, Set<EntityBuilder> entityBuilders,
+    private static void buildAndValidateAnnotatedBundle(Bundle bundle,
+                                                        AnnotatedBundle annotatedBundle,
+                                                        Set<EntityBuilder> entityBuilders,
                                                         String expEncassPolicyName, String expEncassPolicyAction, String expEncassName, String expEncassAction,
                                                         String expDepEncassPolicyName, String expDepEncassPolicyAction, String expDepEncassName, String expDepEncassAction) {
         BundleEntityBuilder builder = new BundleEntityBuilder(entityBuilders, new BundleDocumentBuilder(),
                 new BundleMetadataBuilder(ID_GENERATOR), entityTypeRegistry);
-        Map<String, BundleArtifacts> bundles = builder.build(bundle, BundleType.DEPLOYMENT,
+        Map<String, BundleArtifacts> bundles = builder.build(bundle, DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
@@ -231,18 +234,29 @@ class BundleEntityBuilderTest {
             assertEquals(EntityTypes.FOLDER_TYPE, getSingleChildElementTextContent(folderElement, TYPE));
             assertNotNull(getSingleChildElement(folderElement, RESOURCE));
             final Element policyElement = itemList.get(1);
+
+            expEncassPolicyName = annotatedBundle.applyUniqueName(expEncassPolicyName, DEPLOYMENT, false);
             assertEquals(expEncassPolicyName, getSingleChildElementTextContent(policyElement, NAME));
             assertEquals(EntityTypes.POLICY_TYPE, getSingleChildElementTextContent(policyElement, TYPE));
             assertNotNull(getSingleChildElement(policyElement, RESOURCE));
             final Element depPolicyElement = itemList.get(2);
+
+            Policy depEncassPolicy = bundle.getPolicies().get(expDepEncassPolicyName);
+            expDepEncassPolicyName = annotatedBundle.applyUniqueName(expDepEncassPolicyName, DEPLOYMENT,
+                    depEncassPolicy.isShared());
             assertEquals(expDepEncassPolicyName, getSingleChildElementTextContent(depPolicyElement, NAME));
             assertEquals(EntityTypes.POLICY_TYPE, getSingleChildElementTextContent(depPolicyElement, TYPE));
             assertNotNull(getSingleChildElement(depPolicyElement, RESOURCE));
             final Element encassElement = itemList.get(3);
+
+            expEncassName = annotatedBundle.applyUniqueName(expEncassName, DEPLOYMENT, false);
             assertEquals(expEncassName, getSingleChildElementTextContent(encassElement, NAME));
             assertEquals(EntityTypes.ENCAPSULATED_ASSERTION_TYPE, getSingleChildElementTextContent(encassElement, TYPE));
             assertNotNull(getSingleChildElement(encassElement, RESOURCE));
             final Element depEncassElement = itemList.get(4);
+
+            Encass depEncass = bundle.getEncasses().get(expDepEncassName);
+            expDepEncassName = annotatedBundle.applyUniqueName(expDepEncassName, DEPLOYMENT, depEncass.isShared());
             assertEquals(expDepEncassName, getSingleChildElementTextContent(depEncassElement, NAME));
             assertEquals(EntityTypes.ENCAPSULATED_ASSERTION_TYPE, getSingleChildElementTextContent(depEncassElement, TYPE));
             assertNotNull(getSingleChildElement(depEncassElement, RESOURCE));
@@ -283,7 +297,7 @@ class BundleEntityBuilderTest {
         Encass encass = buildTestEncassWithAnnotation(TEST_GUID, TEST_ENCASS_POLICY, false);
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
-        Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
+        Map<String, BundleArtifacts> bundles = builder.build(bundle, DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
@@ -334,7 +348,7 @@ class BundleEntityBuilderTest {
         Encass encass = buildTestEncassWithAnnotation(TEST_GUID, TEST_ENCASS_POLICY, false);
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
-        Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
+        Map<String, BundleArtifacts> bundles = builder.build(bundle, DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
@@ -404,7 +418,7 @@ class BundleEntityBuilderTest {
         Encass encass = buildTestEncassWithAnnotation(TEST_GUID, TEST_ENCASS_POLICY, true);
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
-        Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
+        Map<String, BundleArtifacts> bundles = builder.build(bundle, DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
@@ -474,7 +488,7 @@ class BundleEntityBuilderTest {
         Encass encass = buildTestEncassWithAnnotation(TEST_GUID, TEST_ENCASS_POLICY, false);
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
-        Map<String, BundleArtifacts> bundles = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT,
+        Map<String, BundleArtifacts> bundles = builder.build(bundle, DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
@@ -533,14 +547,17 @@ class BundleEntityBuilderTest {
         Service service = buildTestServiceWithAnnotation(TEST_SERVICE, TEST_SERVICE_ID, TEST_SERVICE);
         bundle.getServices().put(TEST_SERVICE, service);
 
-        buildAndValidateAnnotatedServiceBundle(bundle, TEST_SERVICE, NEW_OR_EXISTING,
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, service.getAnnotatedEntity(), projectInfo);
+        buildAndValidateAnnotatedServiceBundle(bundle, annotatedBundle, TEST_SERVICE, NEW_OR_EXISTING,
                 TEST_DEP_ENCASS_POLICY, NEW_OR_EXISTING, TEST_DEP_ENCASS, NEW_OR_EXISTING);
     }
 
-    private static void buildAndValidateAnnotatedServiceBundle(Bundle bundle, String expServiceName, String expServiceAction, String expDepEncassPolicyName, String expDepEncassPolicyAction,
+    private static void buildAndValidateAnnotatedServiceBundle(Bundle bundle, AnnotatedBundle annotatedBundle,
+                                                               String expServiceName, String expServiceAction,
+                                                               String expDepEncassPolicyName, String expDepEncassPolicyAction,
                                                                String expDepEncassName, String expDepEncassAction) {
         BundleEntityBuilder builder = createBundleEntityBuilder();
-        Map<String, BundleArtifacts> bundles = builder.build(bundle, BundleType.DEPLOYMENT,
+        Map<String, BundleArtifacts> bundles = builder.build(bundle, DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
@@ -560,10 +577,14 @@ class BundleEntityBuilderTest {
             assertEquals(EntityTypes.FOLDER_TYPE, getSingleChildElementTextContent(folderElement, TYPE));
             assertNotNull(getSingleChildElement(folderElement, RESOURCE));
             final Element depPolicyElement = itemList.get(1);
+
+            expDepEncassPolicyName = annotatedBundle.applyUniqueName(expDepEncassPolicyName, DEPLOYMENT, true);
             assertEquals(expDepEncassPolicyName, getSingleChildElementTextContent(depPolicyElement, NAME));
             assertEquals(EntityTypes.POLICY_TYPE, getSingleChildElementTextContent(depPolicyElement, TYPE));
             assertNotNull(getSingleChildElement(depPolicyElement, RESOURCE));
             final Element depEncassElement = itemList.get(2);
+
+            expDepEncassName = annotatedBundle.applyUniqueName(expDepEncassName, DEPLOYMENT, true);
             assertEquals(expDepEncassName, getSingleChildElementTextContent(depEncassElement, NAME));
             assertEquals(EntityTypes.ENCAPSULATED_ASSERTION_TYPE, getSingleChildElementTextContent(depEncassElement, TYPE));
             assertNotNull(getSingleChildElement(depEncassElement, RESOURCE));

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
@@ -166,10 +166,8 @@ public class BundleEntityBuilderTestHelper {
         bundleHintsAnnotation.setName(TEST_SERVICE_ANNOTATION_NAME);
         bundleHintsAnnotation.setDescription(TEST_SERVICE_ANNOTATION_DESC);
         bundleHintsAnnotation.setTags(TEST_SERVICE_ANNOTATION_TAGS);
-        Annotation sharedAnnotation = new Annotation(AnnotationType.SHARED);
         serviceAnnotations.add(bundleAnnotation);
         serviceAnnotations.add(bundleHintsAnnotation);
-        serviceAnnotations.add(sharedAnnotation);
 
         Service service = new Service();
         service.setHttpMethods(Stream.of("POST", "GET").collect(Collectors.toSet()));
@@ -351,7 +349,8 @@ public class BundleEntityBuilderTestHelper {
 
         Policy depEncassPolicy = buildTestPolicyWithAnnotation(TEST_DEP_ENCASS_POLICY, TEST_DEP_POLICY_ID, TEST_GUID, Collections.emptySet());
         bundle.getPolicies().put(TEST_DEP_ENCASS_POLICY, depEncassPolicy);
-        Encass depEncass = buildTestEncassWithAnnotation(TEST_DEP_ENCASS, TEST_DEP_ENCASS_ID, TEST_GUID, TEST_DEP_ENCASS_POLICY, Collections.emptySet());
+        Encass depEncass = buildTestEncassWithAnnotation(TEST_DEP_ENCASS, TEST_DEP_ENCASS_ID, TEST_GUID,
+                TEST_DEP_ENCASS_POLICY, Collections.singleton(AnnotableEntity.SHARED_ANNOTATION));
         bundle.getEncasses().put(TEST_DEP_ENCASS, depEncass);
 
         Set<Dependency> usedEntities = new LinkedHashSet<>();

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.ca.apim.gateway.cagatewayconfig.beans.Folder.ROOT_FOLDER;
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.DEPLOYMENT;
 import static com.ca.apim.gateway.cagatewayconfig.util.TestUtils.createFolder;
 import static com.ca.apim.gateway.cagatewayconfig.util.TestUtils.createRoot;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.*;
@@ -433,7 +434,10 @@ public class BundleEntityBuilderTestHelper {
         Optional<Metadata> definedEntities = metadata.getDefinedEntities().stream().findFirst();
         assertTrue(definedEntities.isPresent());
         assertEquals("ENCAPSULATED_ASSERTION", definedEntities.get().getType());
-        assertEquals(encass.getName(), definedEntities.get().getName());
+
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, encass.getAnnotatedEntity(), projectInfo);
+        String name = annotatedBundle.applyUniqueName(encass.getAnnotatedEntity().getEntityName(), DEPLOYMENT);
+        assertEquals(name, definedEntities.get().getName());
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writeValueAsString(definedEntities.get());
         Assert.assertThat(json, CoreMatchers.containsString("\"arguments\":[{\"type\":\"message\",\"name\":\"source\",\"requireExplicit\":true,\"label\":\"Some label\"}]"));

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncapsulatedAssertionBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncapsulatedAssertionBuilderTest.java
@@ -1,5 +1,6 @@
 package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.Annotation;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.Encass;
@@ -17,6 +18,7 @@ import org.w3c.dom.Element;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.DEPLOYMENT;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
 import static org.junit.jupiter.api.Assertions.*;
@@ -28,6 +30,7 @@ public class EncapsulatedAssertionBuilderTest {
     private final String TEST_ENCASS = "EncassName";
     private EncapsulatedAssertionBuilder encapsulatedAssertionBuilder = new EncapsulatedAssertionBuilder();
     private PolicyBuilderContext policyBuilderContext;
+    private static final ProjectInfo projectInfo = new ProjectInfo("my-bundle", "my-bundle-group", "1.0", "qa");
 
     @BeforeEach
     void beforeEach() {
@@ -89,7 +92,7 @@ public class EncapsulatedAssertionBuilderTest {
         encass.setName(TEST_ENCASS);
         encass.setPolicy(policyPath);
         Set<Annotation> annotations = new HashSet<>();
-        annotations.add(new Annotation(AnnotationType.SHARED));
+        //annotations.add(new Annotation(AnnotationType.SHARED));
         Annotation annotation = new Annotation(AnnotationType.BUNDLE_HINTS);
         annotation.setGuid("");
         annotation.setId("");
@@ -98,8 +101,8 @@ public class EncapsulatedAssertionBuilderTest {
         bundle.getEncasses().put(TEST_ENCASS, encass);
 
         //empty guid and goid
-        AnnotatedEntity annotatedEntity = new AnnotatedEntity(encass);
-        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, null);
+        AnnotatedEntity annotatedEntity = encass.getAnnotatedEntity();
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, projectInfo);
         annotatedBundle.putAllEncasses(org.testcontainers.shaded.com.google.common.collect.ImmutableMap.of(TEST_ENCASS, encass));
         annotatedBundle.getPolicies().put(policyPath, policy);
         Element encapsulatedAssertionElement = createEncapsulatedAssertionElement(document);
@@ -110,13 +113,14 @@ public class EncapsulatedAssertionBuilderTest {
         encapsulatedAssertionBuilder.buildAssertionElement(encapsulatedAssertionElement, policyBuilderContext);
 
         Element nameElement = getSingleElement(encapsulatedAssertionElement, ENCAPSULATED_ASSERTION_CONFIG_NAME);
-        assertEquals(TEST_ENCASS, nameElement.getAttribute(PolicyEntityBuilder.STRING_VALUE));
+        String name = annotatedBundle.applyUniqueName(TEST_ENCASS, DEPLOYMENT, false);
+        assertEquals(name, nameElement.getAttribute(PolicyEntityBuilder.STRING_VALUE));
 
         Element guidElement = getSingleElement(encapsulatedAssertionElement, ENCAPSULATED_ASSERTION_CONFIG_GUID);
         assertEquals(encass.getGuid(), guidElement.getAttribute(PolicyEntityBuilder.STRING_VALUE));
 
         //wrong guid and goid
-        annotatedEntity = new AnnotatedEntity(encass);
+        annotatedEntity = encass.getAnnotatedEntity();
         annotations = new HashSet<>();
         annotations.add(new Annotation(AnnotationType.SHARED));
         annotation = new Annotation(AnnotationType.BUNDLE_HINTS);
@@ -125,7 +129,7 @@ public class EncapsulatedAssertionBuilderTest {
         annotations.add(annotation);
         encass.setAnnotations(annotations);
         encass.setAnnotatedEntity(null);
-        annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, null);
+        annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, projectInfo);
         annotatedBundle.putAllEncasses(org.testcontainers.shaded.com.google.common.collect.ImmutableMap.of(TEST_ENCASS, encass));
         annotatedBundle.getPolicies().put(policyPath, policy);
         encapsulatedAssertionElement = createEncapsulatedAssertionElement(document);

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilderTest.java
@@ -6,6 +6,7 @@
 
 package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
@@ -34,6 +35,7 @@ class EncassEntityBuilderTest {
     private static final String TEST_GUID = UUID.randomUUID().toString();
     private static final String TEST_POLICY_ID = "PolicyID";
     private static final String TEST_GOID = ID_GENERATOR.generate();
+    private static final ProjectInfo projectInfo = new ProjectInfo("my-bundle", "my-bundle-group", "1.0", "qa");
 
     @Test
     void buildFromEmptyBundle_noEncass() {
@@ -69,14 +71,15 @@ class EncassEntityBuilderTest {
         annotations.add(annotation);
         annotations.add(new Annotation(AnnotationType.SHARED));
         encass.setAnnotations(annotations);
+        encass.setParentEntityShared(encass.getAnnotations().contains(new Annotation(AnnotationType.SHARED)));
         bundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
 
         Policy policy = new Policy();
         policy.setName(TEST_POLICY_PATH);
         policy.setId(TEST_POLICY_ID);
         bundle.getPolicies().put(TEST_POLICY_PATH, policy);
-        AnnotatedEntity annotatedEntity = new AnnotatedEntity(encass);
-        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, null);
+        AnnotatedEntity annotatedEntity = encass.getAnnotatedEntity();
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, projectInfo);
         annotatedBundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
         annotatedBundle.getPolicies().put(TEST_POLICY_PATH, policy);
         List<Entity> entities = builder.build(annotatedBundle, BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
@@ -85,7 +88,8 @@ class EncassEntityBuilderTest {
         assertEquals(1, entities.size());
 
         Entity entity = entities.get(0);
-        assertEquals(TEST_ENCASS, entity.getName());
+        String name = annotatedBundle.applyUniqueName(TEST_ENCASS, BundleType.DEPLOYMENT, true);
+        assertEquals(name, entity.getName());
         assertNotNull(entity.getId(), TEST_GOID);
         assertEquals(entity.getGuid(), TEST_GUID);
 
@@ -97,15 +101,17 @@ class EncassEntityBuilderTest {
         annotations.add(annotation);
         annotations.add(new Annotation(AnnotationType.SHARED));
         encass.setAnnotations(annotations);
+        encass.setParentEntityShared(encass.getAnnotations().contains(new Annotation(AnnotationType.SHARED)));
         encass.setAnnotatedEntity(null);
-        annotatedEntity = new AnnotatedEntity(encass);
-        annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, null);
+        annotatedEntity = encass.getAnnotatedEntity();
+        annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, projectInfo);
         annotatedBundle.putAllEncasses(ImmutableMap.of(TEST_ENCASS, encass));
         annotatedBundle.getPolicies().put(TEST_POLICY_PATH, policy);
         entities = builder.build(annotatedBundle, BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
 
         entity = entities.get(0);
-        assertEquals(TEST_ENCASS, entity.getName());
+        name = annotatedBundle.applyUniqueName(TEST_ENCASS, BundleType.DEPLOYMENT, true);
+        assertEquals(name, entity.getName());
         assertNotNull(entity.getId(), TEST_GOID);
         assertEquals(entity.getGuid(), TEST_GUID);
     }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IncludeAssertionBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IncludeAssertionBuilderTest.java
@@ -1,5 +1,6 @@
 package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
+import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.Policy;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
@@ -23,6 +24,7 @@ public class IncludeAssertionBuilderTest {
     private Document document;
     private IncludeAssertionBuilder includeAssertionBuilder = new IncludeAssertionBuilder();
     private PolicyBuilderContext policyBuilderContext;
+    private static final ProjectInfo projectInfo = new ProjectInfo("my-bundle", "my-bundle-group", "1.0");
 
     @BeforeEach
     void beforeEach() {
@@ -40,12 +42,14 @@ public class IncludeAssertionBuilderTest {
         Policy policy = new Policy();
         policy.setGuid("123-abc-567");
         bundle.getPolicies().put(policyPath, policy);
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, null, null);
+        annotatedBundle.putAllPolicies(bundle.getPolicies());
 
         Element includeAssertionElement = createIncludeAssertionElement(document, policyPath);
         document.appendChild(includeAssertionElement);
         policyBuilderContext = new PolicyBuilderContext("path.xml", document, bundle, new IdGenerator());
         policyBuilderContext.withPolicy(policy);
-        policyBuilderContext.withAnnotatedBundle(new AnnotatedBundle(bundle, null, null));
+        policyBuilderContext.withAnnotatedBundle(annotatedBundle);
         includeAssertionBuilder.buildAssertionElement(includeAssertionElement, policyBuilderContext);
 
         Element policyGuidElement = getSingleElement(includeAssertionElement, POLICY_GUID);
@@ -59,13 +63,15 @@ public class IncludeAssertionBuilderTest {
         Policy policy = new Policy();
         policy.setGuid("123-abc-567");
         bundle.getPolicies().put(policyPath, policy);
+        AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, null, null);
+        annotatedBundle.putAllPolicies(bundle.getPolicies());
 
         Element includeAssertionElement = createIncludeAssertionElement(document, policyPath);
         document.appendChild(includeAssertionElement);
 
         policyBuilderContext = new PolicyBuilderContext("path.xml", document, bundle, new IdGenerator());
         policyBuilderContext.withPolicy(policy);
-        policyBuilderContext.withAnnotatedBundle(new AnnotatedBundle(bundle, null, null));
+        policyBuilderContext.withAnnotatedBundle(annotatedBundle);
         includeAssertionBuilder.buildAssertionElement(includeAssertionElement, policyBuilderContext);
 
         Element policyGuidElement = getSingleElement(includeAssertionElement, POLICY_GUID);

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilderTest.java
@@ -158,7 +158,10 @@ class PolicyEntityBuilderTest {
         annotation.setGuid("");
         annotation.setId("");
         annotations.add(annotation);
+        annotation = new Annotation(AnnotationType.SHARED);
+        annotations.add(annotation);
         policy.setAnnotations(annotations);
+        policy.setParentEntityShared(policy.isShared());
 
         Encass encass = new Encass();
         encass.setGuid("encassGuid");
@@ -167,11 +170,12 @@ class PolicyEntityBuilderTest {
         annotations = new HashSet<>();
         annotations.add(encassAnnotation);
         encass.setAnnotations(annotations);
+        encass.setParentEntityShared(encass.isShared());
         bundle.getEncasses().put(TEST_ENCASS, encass);
         bundle.getPolicies().put("Policy", policy);
 
 
-        AnnotatedEntity annotatedEntity = new AnnotatedEntity(encass);
+        AnnotatedEntity annotatedEntity = encass.getAnnotatedEntity();
         annotatedEntity.setEntityName(encass.getName());
         AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, annotatedEntity, new ProjectInfo("", "", ""));
         annotatedBundle.putAllEncasses(org.testcontainers.shaded.com.google.common.collect.ImmutableMap.of(TEST_ENCASS, encass));
@@ -210,7 +214,11 @@ class PolicyEntityBuilderTest {
     @Test
     void maybeAddPolicy() {
         Policy policy1 = new Policy();
+        policy1.setName("policy1");
+        policy1.setPath("policy1");
         Policy policy2 = new Policy();
+        policy2.setName("policy2");
+        policy2.setPath("policy2");
         policy1.getDependencies().add(policy2);
 
         ArrayList<Policy> orderedPolicies = new ArrayList<>();


### PR DESCRIPTION
## Description
Revisiting Shared annotation usage.
- `@shared` annotation can be applied only to Policy or Encass.
- `@shared` can be applied to sub-entities only instead of at `@bundle` level
- Unique naming applies to all entities irrespective they have `@shared` annotation or not. Naming conversion differs (mentioned below).

#### Unique Naming convention
| Type | Format |
| --- | --- |
| Non-Shared | `::<groupName>.<bundleName>::<entityName>::<version>` |
| Shared | `::<groupName>::<entityName>` |
