### PR TITLE
NORALLY: identifying missing entities by folder path filter

### DIFF
--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundle.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundle.java
@@ -9,6 +9,7 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadException;
 import com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry;
+import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.string.CharacterBlacklistUtil;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
@@ -45,7 +46,7 @@ public class ExplodeBundle {
         if (folderPath.equals("/")) {
             return true;
         }
-        return bundle.getFolders().values().stream().anyMatch( folder -> ("/" + folder.getPath()).equals(folderPath));
+        return bundle.getFolders().values().stream().anyMatch( folder -> ("/" + PathUtils.unixPath(folder.getPath())).equals(folderPath));
     }
 
     void explodeBundle(String folderPath, FilterConfiguration filterConfiguration, File bundleFile, File explodeDirectory) throws DocumentParseException {

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/EncapsulatedAssertionSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/EncapsulatedAssertionSimplifier.java
@@ -35,30 +35,43 @@ public class EncapsulatedAssertionSimplifier implements PolicyAssertionSimplifie
     public void simplifyAssertionElement(PolicySimplifierContext context) throws DocumentParseException {
         Element encapsulatedAssertionElement = context.getAssertionElement();
         Bundle bundle = context.getBundle();
+        Bundle resultantBundle = context.getResultantBundle();
 
         Element encassGuidElement = getSingleElement(encapsulatedAssertionElement, ENCAPSULATED_ASSERTION_CONFIG_GUID);
         String encassGuid = encassGuidElement.getAttribute(STRING_VALUE);
-        Optional<Encass> encassEntity = bundle.getEntities(Encass.class).values().stream().filter(e -> encassGuid.equals(e.getGuid())).findAny();
-        if (encassEntity.isPresent()) {
-            Policy policyEntity = bundle.getPolicies().values().stream().filter(p -> encassEntity.get().getPolicyId().equals(p.getId())).findFirst().orElse(null);
-            if (policyEntity != null) {
-                encapsulatedAssertionElement.setAttribute("encassName", encassEntity.get().getName());
+
+        // Look for the referenced encass from the resultant-bundle (i.e., filtered bundle)
+        // if it is not found, we should considered it as missing-entity.
+        //  - if the entity is found in the original exported bundle, missing-entity will be marked as excluded.
+        //  - otherwise, it will be marked as not-excluded, i.e., entity might be missing from the gateway itself.
+        // NOTE: Same rule is applicable to policies as well.
+        Optional<Encass> resultantEncassEntity = resultantBundle.getEntities(Encass.class).values().stream().filter(e -> encassGuid.equals(e.getGuid())).findAny();
+        if (resultantEncassEntity.isPresent()) {
+            Optional<Policy> resultantPolicyEntity = resultantBundle.getPolicies().values().stream().filter(p -> resultantEncassEntity.get().getPolicyId().equals(p.getId())).findFirst();
+            if (resultantPolicyEntity.isPresent()) {
+                encapsulatedAssertionElement.setAttribute("encassName", resultantEncassEntity.get().getName());
                 Element encapsulatedAssertionConfigNameElement = getSingleChildElement(encapsulatedAssertionElement, ENCAPSULATED_ASSERTION_CONFIG_NAME, true);
                 if (encapsulatedAssertionConfigNameElement != null) {
                     encapsulatedAssertionElement.removeChild(encapsulatedAssertionConfigNameElement);
                 }
                 encapsulatedAssertionElement.removeChild(encassGuidElement);
             } else {
-                LOGGER.log(Level.WARNING, "Could not find referenced encass policy with id: {0}", encassEntity.get().getPolicyId());
-                simplifyAssertionElementForMissingEntity(context, encapsulatedAssertionElement);
+                Optional<Policy> policyEntity = bundle.getPolicies().values().stream().filter(p -> resultantEncassEntity.get().getPolicyId().equals(p.getId())).findFirst();
+                if (!policyEntity.isPresent()) {
+                    LOGGER.log(Level.WARNING, "Could not find referenced encass policy with id: {0}", resultantEncassEntity.get().getPolicyId());
+                }
+                simplifyAssertionElementForMissingEntity(context, encapsulatedAssertionElement, policyEntity.isPresent());
             }
         } else {
-            LOGGER.log(Level.WARNING, "Could not find referenced encass with guid: {0}", encassGuid);
-            simplifyAssertionElementForMissingEntity(context, encapsulatedAssertionElement);
+            Optional<Encass> encassEntity = bundle.getEntities(Encass.class).values().stream().filter(e -> encassGuid.equals(e.getGuid())).findAny();
+            if (!encassEntity.isPresent()) {
+                LOGGER.log(Level.WARNING, "Could not find referenced encass with guid: {0}", encassGuid);
+            }
+            simplifyAssertionElementForMissingEntity(context, encapsulatedAssertionElement, encassEntity.isPresent());
         }
     }
 
-    private void simplifyAssertionElementForMissingEntity(final PolicySimplifierContext context, final Element encassAssertionElement) {
+    private void simplifyAssertionElementForMissingEntity(final PolicySimplifierContext context, final Element encassAssertionElement, final boolean excluded) {
         final Element encassGuidElement = getSingleChildElement(encassAssertionElement, ENCAPSULATED_ASSERTION_CONFIG_GUID);
         final Element encassNameElement = getSingleChildElement(encassAssertionElement, ENCAPSULATED_ASSERTION_CONFIG_NAME, true);
 
@@ -67,6 +80,7 @@ public class EncapsulatedAssertionSimplifier implements PolicyAssertionSimplifie
         missingEntity.setGuid(encassGuidElement.getAttribute(STRING_VALUE));
         missingEntity.setName(encassNameElement != null ? encassNameElement.getAttribute(STRING_VALUE) : "Encass#" + missingEntity.getGuid());
         missingEntity.setId(missingEntity.getGuid().replace("-", ""));
+        missingEntity.setExcluded(excluded);
         context.getResultantBundle().addEntity(missingEntity);
 
         encassAssertionElement.setAttribute("encassName", missingEntity.getName());

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/IncludeAssertionSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/IncludeAssertionSimplifier.java
@@ -54,10 +54,10 @@ public class IncludeAssertionSimplifier implements PolicyAssertionSimplifier {
 
             final MissingGatewayEntity missingEntity = new MissingGatewayEntity();
             missingEntity.setType(EntityTypes.POLICY_TYPE);
-            missingEntity.setName("Policy#" + includedPolicyGuid);
+            missingEntity.setName(policyEntity.isPresent() ? policyEntity.get().getName() : "Policy#" + includedPolicyGuid);
             missingEntity.setGuid(includedPolicyGuid);
             missingEntity.setExcluded(excluded);
-            missingEntity.setId(missingEntity.getGuid().replace("-", ""));
+            missingEntity.setId(policyEntity.isPresent() ? policyEntity.get().getId() : missingEntity.getGuid().replace("-", ""));
 
             context.getResultantBundle().addEntity(missingEntity);
 

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/IncludeAssertionSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/IncludeAssertionSimplifier.java
@@ -54,7 +54,7 @@ public class IncludeAssertionSimplifier implements PolicyAssertionSimplifier {
 
             final MissingGatewayEntity missingEntity = new MissingGatewayEntity();
             missingEntity.setType(EntityTypes.POLICY_TYPE);
-            missingEntity.setName(policyEntity.isPresent() ? policyEntity.get().getName() : "Policy#" + includedPolicyGuid);
+            missingEntity.setName(policyEntity.isPresent() ? getPolicyPath(bundle, policyEntity.get()) : "Policy#" + includedPolicyGuid);
             missingEntity.setGuid(includedPolicyGuid);
             missingEntity.setExcluded(excluded);
             missingEntity.setId(policyEntity.isPresent() ? policyEntity.get().getId() : missingEntity.getGuid().replace("-", ""));

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
@@ -405,6 +405,7 @@ class PolicyXMLSimplifierTest {
     void simplifyEncapsulatedAssertion() throws DocumentParseException {
         Element encapsulatedAssertion = createEncapsulatedAssertion();
         Bundle bundle = new Bundle();
+        Bundle resultantBundle = new Bundle();
         Encass encass = new Encass();
         encass.setGuid("Test Guid");
         encass.setName("Test Name");
@@ -419,7 +420,7 @@ class PolicyXMLSimplifierTest {
                         new PolicySimplifierContext(
                                 "Policy",
                                 bundle,
-                                null)
+                                resultantBundle)
                                 .withAssertionElement(encapsulatedAssertion)
                 );
 

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
@@ -322,6 +322,7 @@ class PolicyXMLSimplifierTest {
 
         assertEquals(testName, getSingleChildElementAttribute(includeAssertion, POLICY_GUID, "policyPath"));
         assertNull(getSingleChildElementAttribute(includeAssertion, POLICY_GUID, STRING_VALUE));
+        assertTrue(resultantBundle.getMissingEntities().isEmpty());
     }
 
     @Test
@@ -344,8 +345,42 @@ class PolicyXMLSimplifierTest {
                                 .withAssertionElement(includeAssertion)
                 );
 
-        assertTrue(getSingleChildElementAttribute(includeAssertion, POLICY_GUID, "policyPath").startsWith("Policy#"));
+        assertNotEquals(testName, getSingleChildElementAttribute(includeAssertion, POLICY_GUID, "policyPath"));
         assertNull(getSingleChildElementAttribute(includeAssertion, POLICY_GUID, STRING_VALUE));
+        assertTrue(getSingleChildElementAttribute(includeAssertion, POLICY_GUID, "policyPath").startsWith("Policy#"));
+        assertFalse(resultantBundle.getMissingEntities().isEmpty());
+    }
+
+    @Test
+    void simplifyIncludeAssertionMissingPolicyInResultantBundleOnly() throws DocumentParseException {
+        String id = new IdGenerator().generate();
+        String testName = "test";
+        Policy policy = new Policy.Builder()
+                .setGuid(id)
+                .setName(testName)
+                .setParentFolderId(ROOT_FOLDER_ID)
+                .build();
+        Bundle bundle = new Bundle();
+        Bundle resultantBundle = new Bundle();
+        bundle.addEntity(ROOT_FOLDER);
+        FolderTree folderTree = new FolderTree(bundle.getEntities(Folder.class).values());
+        bundle.setFolderTree(folderTree);
+        bundle.addEntity(policy);
+
+        Element includeAssertion = createIncludeAssertionElement(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), id);
+        new IncludeAssertionSimplifier()
+                .simplifyAssertionElement(
+                        new PolicySimplifierContext(
+                                "policy",
+                                bundle,
+                                resultantBundle)
+                                .withAssertionElement(includeAssertion)
+                );
+
+        assertEquals(testName, getSingleChildElementAttribute(includeAssertion, POLICY_GUID, "policyPath"));
+        assertNull(getSingleChildElementAttribute(includeAssertion, POLICY_GUID, STRING_VALUE));
+        assertFalse(resultantBundle.getMissingEntities().isEmpty());
+        assertNotNull(resultantBundle.getMissingEntities().get(policy.getId()));
     }
 
     @Test
@@ -414,6 +449,8 @@ class PolicyXMLSimplifierTest {
         policy.setId("Policy");
         bundle.getEncasses().put(encass.getGuid(), encass);
         bundle.getPolicies().put(policy.getId(), policy);
+        resultantBundle.getEncasses().put(encass.getGuid(), encass);
+        resultantBundle.getPolicies().put(policy.getId(), policy);
 
         new EncapsulatedAssertionSimplifier()
                 .simplifyAssertionElement(
@@ -427,6 +464,7 @@ class PolicyXMLSimplifierTest {
         assertEquals("Test Name", encapsulatedAssertion.getAttribute("encassName"));
         assertNull(getSingleChildElement(encapsulatedAssertion, ENCAPSULATED_ASSERTION_CONFIG_NAME, true));
         assertNull(getSingleChildElement(encapsulatedAssertion, ENCAPSULATED_ASSERTION_CONFIG_GUID, true));
+        assertTrue(resultantBundle.getMissingEntities().isEmpty());
     }
 
     @Test
@@ -439,6 +477,7 @@ class PolicyXMLSimplifierTest {
         encass.setName("Test Name");
         encass.setPolicyId("Policy");
         bundle.getEncasses().put(encass.getGuid(), encass);
+        resultantBundle.getEncasses().put(encass.getGuid(), encass);
 
         new EncapsulatedAssertionSimplifier()
                 .simplifyAssertionElement(
@@ -452,6 +491,7 @@ class PolicyXMLSimplifierTest {
         assertEquals("Test Name", encapsulatedAssertion.getAttribute("encassName"));
         assertNull(getSingleChildElement(encapsulatedAssertion, ENCAPSULATED_ASSERTION_CONFIG_NAME, true));
         assertNull(getSingleChildElement(encapsulatedAssertion, ENCAPSULATED_ASSERTION_CONFIG_GUID, true));
+        assertNotNull(resultantBundle.getMissingEntities().get("Test Guid"));
     }
 
     @Test
@@ -471,6 +511,7 @@ class PolicyXMLSimplifierTest {
         assertEquals("Test Name", encapsulatedAssertion.getAttribute("encassName"));
         assertNull(getSingleChildElement(encapsulatedAssertion, ENCAPSULATED_ASSERTION_CONFIG_NAME, true));
         assertNull(getSingleChildElement(encapsulatedAssertion, ENCAPSULATED_ASSERTION_CONFIG_GUID, true));
+        assertNotNull(resultantBundle.getMissingEntities().get("Test Guid"));
     }
 
     @Test


### PR DESCRIPTION
## Description

1. **While exporting, dev-plugin fails to mark a few entities as missing due to folder-path filtering.** 
While simplifying the encass and policy references, search should be done first in the filtered-bundle and followed by the actual export bundle. This correction was made to encass-assertion-simplifier. FYI, similar logic was already in place for policy-include-assertion-simplifier.
  
2. **(Windows) - Fails to export gateway configuration using multi-level folder path i.e., /folder/sub-folder.**
We support folder-path configured in unix-path style but whereas while exploding the configuration, a small comparison to verify the exported bundle is made platform dependent. That means, export that is successful on unix platform might fail on Windows platforms. Now the change is made platform independent.

## Links
Link Type   | Link
------      | ------
Rally Issue | 
Func Spec   | 
## Checklist
- [x] Pull Request Created
- [ ] Code Review Completed
- [ ] Veracode scan results addressed
- [ ] SonarQube scan results addressed
- [ ] TPSR has been submitted (if applicable) 
- [ ] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
- [ ] Func Spec has been updated as needed
- [ ] Rally Issue(s) are in an engineering completed state 