### PR TITLE
DE466753 : Fixing the unsupported identity providers issue

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilder.java
@@ -90,7 +90,7 @@ public class IdentityProviderEntityBuilder implements EntityBuilder {
             case POLICY_BACKED:
             default:
                 LOGGER.log(Level.WARNING, "unsupported identity provider type, please add/migrate the entity {0} to target gateway by other utilities.", name);
-                entity = EntityBuilderHelper.getEntityWithNameMapping(ID_PROVIDER_CONFIG_TYPE, name, id, identityProviderElement);
+                entity = EntityBuilderHelper.getEntityWithOnlyMapping(ID_PROVIDER_CONFIG_TYPE, name, id);
                 entity.setMappingAction(NEW_OR_EXISTING);
                 entity.setMappingProperty(FAIL_ON_NEW, true);
                 break;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilder.java
@@ -15,6 +15,8 @@ import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.IdentityProviderType.BIND_ONLY_LDAP;
@@ -30,6 +32,7 @@ import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createE
 @Singleton
 public class IdentityProviderEntityBuilder implements EntityBuilder {
 
+    private static final Logger LOGGER = Logger.getLogger(IdentityProviderEntityBuilder.class.getName());
     private static final Integer ORDER = 1100;
     private static final String TRUSTED_CERT_URI = "http://ns.l7tech.com/2010/04/gateway-management/trustedCertificates";
 
@@ -86,6 +89,7 @@ public class IdentityProviderEntityBuilder implements EntityBuilder {
             case INTERNAL:
             case POLICY_BACKED:
             default:
+                LOGGER.log(Level.WARNING, "unsupported identity provider type, please add/migrate the entity {0} to target gateway by other utilities.", name);
                 entity = EntityBuilderHelper.getEntityWithNameMapping(ID_PROVIDER_CONFIG_TYPE, name, id, identityProviderElement);
                 entity.setMappingAction(NEW_OR_EXISTING);
                 entity.setMappingProperty(FAIL_ON_NEW, true);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilder.java
@@ -17,9 +17,13 @@ import javax.inject.Singleton;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.IdentityProviderType.BIND_ONLY_LDAP;
+import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.IdentityProviderType.FEDERATED;
 import static com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes.ID_PROVIDER_CONFIG_TYPE;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.buildAndAppendPropertiesElement;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions.NEW_OR_EXISTING;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties.FAIL_ON_NEW;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithAttribute;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithTextContent;
 
@@ -46,11 +50,11 @@ public class IdentityProviderEntityBuilder implements EntityBuilder {
             case DEPLOYMENT:
                 return entities.entrySet().stream()
                         .map(
-                                identityProviderEntry -> EntityBuilderHelper.getEntityWithOnlyMapping(ID_PROVIDER_CONFIG_TYPE, bundle.applyUniqueName(identityProviderEntry.getKey(), BundleType.ENVIRONMENT), generateId((IdentityProvider)identityProviderEntry.getValue()))
+                                identityProviderEntry -> EntityBuilderHelper.getEntityWithOnlyMapping(ID_PROVIDER_CONFIG_TYPE, generateUniqueName(bundle, identityProviderEntry.getKey(), (IdentityProvider)identityProviderEntry.getValue()), generateId((IdentityProvider)identityProviderEntry.getValue()))
                         ).collect(Collectors.toList());
             case ENVIRONMENT:
                 return entities.entrySet().stream().map(identityProviderEntry ->
-                        buildIdentityProviderEntity(bundle, bundle.applyUniqueName(identityProviderEntry.getKey(), bundleType), (IdentityProvider)identityProviderEntry.getValue(), document)
+                        buildIdentityProviderEntity(bundle, generateUniqueName(bundle, identityProviderEntry.getKey(), (IdentityProvider)identityProviderEntry.getValue()), (IdentityProvider)identityProviderEntry.getValue(), document)
                 ).collect(Collectors.toList());
             default:
                 throw new EntityBuilderException("Unknown bundle type: " + bundleType);
@@ -67,22 +71,28 @@ public class IdentityProviderEntityBuilder implements EntityBuilder {
                     document, identityProviderElement);
         }
 
+        Entity entity = null;
         switch (identityProvider.getType()) {
             case BIND_ONLY_LDAP:
                 identityProviderElement.appendChild(buildBindOnlyLdapIPDetails(identityProvider, document));
+                entity = EntityBuilderHelper.getEntityWithNameMapping(ID_PROVIDER_CONFIG_TYPE, name, id, identityProviderElement);
                 break;
             case FEDERATED:
                 final FederatedIdentityProviderDetail identityProviderDetail = (FederatedIdentityProviderDetail) identityProvider.getIdentityProviderDetail();
                 appendFedIdProvDetails(bundle, identityProviderDetail, document, identityProviderElement);
+                entity = EntityBuilderHelper.getEntityWithNameMapping(ID_PROVIDER_CONFIG_TYPE, name, id, identityProviderElement);
                 break;
             case LDAP:
             case INTERNAL:
             case POLICY_BACKED:
             default:
-                throw new EntityBuilderException("Please Specify the Identity Provider Type as one of: 'BIND_ONLY_LDAP', 'FEDERATED'");
+                entity = EntityBuilderHelper.getEntityWithNameMapping(ID_PROVIDER_CONFIG_TYPE, name, id, identityProviderElement);
+                entity.setMappingAction(NEW_OR_EXISTING);
+                entity.setMappingProperty(FAIL_ON_NEW, true);
+                break;
         }
 
-        return EntityBuilderHelper.getEntityWithNameMapping(ID_PROVIDER_CONFIG_TYPE, name, id, identityProviderElement);
+        return entity;
     }
 
     private void appendFedIdProvDetails(Bundle bundle,
@@ -166,6 +176,13 @@ public class IdentityProviderEntityBuilder implements EntityBuilder {
             return identityProvider.getAnnotatedEntity().getId();
         }
         return identityProvider.getId();
+    }
+
+    private String generateUniqueName(Bundle bundle, String name, IdentityProvider identityProvider) {
+        if (identityProvider != null && (identityProvider.getType() == BIND_ONLY_LDAP || identityProvider.getType() == FEDERATED)) {
+            return bundle.applyUniqueName(name, BundleType.ENVIRONMENT);
+        }
+        return name;
     }
 
     @Override

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilderTest.java
@@ -33,6 +33,8 @@ import java.util.stream.Stream;
 import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.IdentityProviderType.BIND_ONLY_LDAP;
 import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.IdentityProviderType.FEDERATED;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions.NEW_OR_EXISTING;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties.FAIL_ON_NEW;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getChildElementAttributeValues;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
 import static java.util.Arrays.*;
@@ -64,6 +66,10 @@ class IdentityProviderEntityBuilderTest {
         }});
         final List<Entity> identityProviderEntities = builder.build(bundle, BundleType.ENVIRONMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
         assertEquals(1, identityProviderEntities.size());
+        final Entity identityProviderEntity = identityProviderEntities.get(0);
+        assertEquals("ID_PROVIDER_CONFIG", identityProviderEntity.getType());
+        assertEquals(NEW_OR_EXISTING, identityProviderEntity.getMappingAction());
+        assertTrue(Boolean.valueOf(String.valueOf(identityProviderEntity.getMappingProperties().get(FAIL_ON_NEW))));
     }
 
     @Test

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilderTest.java
@@ -62,7 +62,8 @@ class IdentityProviderEntityBuilderTest {
         bundle.putAllIdentityProviders(new HashMap<String, IdentityProvider>() {{
             put("unsupported idp", identityProvider);
         }});
-        assertThrows(EntityBuilderException.class, () -> builder.build(bundle, BundleType.ENVIRONMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument()));
+        final List<Entity> identityProviderEntities = builder.build(bundle, BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
+        assertEquals(1, identityProviderEntities.size());
     }
 
     @Test

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilderTest.java
@@ -62,7 +62,7 @@ class IdentityProviderEntityBuilderTest {
         bundle.putAllIdentityProviders(new HashMap<String, IdentityProvider>() {{
             put("unsupported idp", identityProvider);
         }});
-        final List<Entity> identityProviderEntities = builder.build(bundle, BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
+        final List<Entity> identityProviderEntities = builder.build(bundle, BundleType.ENVIRONMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
         assertEquals(1, identityProviderEntities.size());
     }
 


### PR DESCRIPTION
Fix for unsupported identity providers type.
Instead of throwing the exception for unsupported identity providers, creating the entity with mapping action NewOrExisting and property FailOnNew to true. So it is policy author responsibility to migrate/add the unsupported identity provider to the target gateway before deploying the policy bundle.

## Links
Link Type   | Link
------      | ------
Rally Issue | 
Func Spec   | 
## Checklist
- [x] Pull Request Created
- [ ] Code Review Completed
- [ ] Veracode scan results addressed
- [ ] SonarQube scan results addressed
- [ ] TPSR has been submitted (if applicable) 
- [ ] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
- [ ] Func Spec has been updated as needed
- [ ] Rally Issue(s) are in an engineering completed state 