### PR TITLE
NORALLY: introducing system property to disable environment entity unique naming strategy

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Bundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Bundle.java
@@ -7,8 +7,6 @@
 package com.ca.apim.gateway.cagatewayconfig.beans;
 
 import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
-import com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleDefinedEntities;
-import com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleMetadata;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder;
 import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadingOperation;
 import com.ca.apim.gateway.cagatewayconfig.util.file.SupplierWithIO;
@@ -19,10 +17,11 @@ import java.io.InputStream;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Bundle {
+
+    private static final String DISABLE_ENVIRONMENT_ENTITY_UNIQUE_NAMING = "com.ca.apim.build.disableEnvironmentEntityUniqueNaming";
 
     // simple map of entities to avoid having to add here a new map for each entity
     private final Map<Class, Map<String, ?>> entities = new ConcurrentHashMap<>();
@@ -332,6 +331,10 @@ public class Bundle {
      */
     public String applyUniqueName(final String entityName, final EntityBuilder.BundleType bundleType,
                                   boolean isShared) {
+        if (bundleType == EntityBuilder.BundleType.ENVIRONMENT && isEnvironmentEntityUniqueNamingDisabled()) {
+            return entityName;
+        }
+
         StringBuilder uniqueName = new StringBuilder(UNIQUE_NAME_SEPARATOR);
         uniqueName.append(getNamespace(bundleType, isShared));
         uniqueName.append(UNIQUE_NAME_SEPARATOR);
@@ -361,6 +364,10 @@ public class Bundle {
      */
     public String getNamespace(final EntityBuilder.BundleType bundleType, boolean isShared) {
         return getProjectInfo().getGroupName();
+    }
+
+    public static boolean isEnvironmentEntityUniqueNamingDisabled() {
+        return Boolean.getBoolean(DISABLE_ENVIRONMENT_ENTITY_UNIQUE_NAMING);
     }
 
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -21,6 +21,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.FILTER_ENV_ENTITIES;
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.*;
@@ -33,7 +35,7 @@ import static java.util.Collections.unmodifiableSet;
 
 @Singleton
 public class BundleEntityBuilder {
-
+    private static final Logger LOGGER = Logger.getLogger(BundleEntityBuilder.class.getName());
     private final Set<EntityBuilder> entityBuilders;
     private final BundleDocumentBuilder bundleDocumentBuilder;
     private final BundleMetadataBuilder bundleMetadataBuilder;
@@ -57,6 +59,9 @@ public class BundleEntityBuilder {
 
     public Map<String, BundleArtifacts> build(Bundle bundle, BundleType bundleType,
                                               Document document, ProjectInfo projectInfo, boolean generateMetadata) {
+        if (Bundle.isEnvironmentEntityUniqueNamingDisabled()) {
+            LOGGER.log(Level.WARNING, "Environment entity unique-naming is disabled");
+        }
 
         Map<String, BundleArtifacts> artifacts = buildAnnotatedEntities(bundleType, bundle, document, projectInfo);
         if (artifacts.isEmpty()) {


### PR DESCRIPTION

## Description  
By default, dev-plugin applies a unique-naming strategy for gateway entities while building the bundles guided by annotations. This might not be acceptable for the existing users who are new to the annotations. Especially, it will break backward compatibility while building the environment bundles at the module level. 

- Introduced a new system property "com.ca.apim.build.disableEnvironmentEntityUniqueNaming" to control the unique-naming strategy for environment entities while building the bundles.
- The default value is false, i.e., a unique-naming strategy applies to environment entities by default.
- As it is not recommended to disable this unique naming strategy, warning the user if this flag is set to true.

## Checklist
- [x] Pull Request Created
- [ ] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
