### PR TITLE
NORALLY: renaming GatewaySourceConfig.targetFolder property to GatewaySourceConfig.targetFolderPath

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/ProjectInfo.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/ProjectInfo.java
@@ -15,7 +15,7 @@ public class ProjectInfo {
     private String majorVersion;
     private String minorVersion;
     private final String configName;
-    private String targetFolder;
+    private String targetFolderPath;
 
     public ProjectInfo(String name, String groupName, String version) {
         this(name, groupName, version, null);
@@ -65,11 +65,11 @@ public class ProjectInfo {
         return configName;
     }
 
-    public String getTargetFolder() {
-        return targetFolder;
+    public String getTargetFolderPath() {
+        return targetFolderPath;
     }
 
-    public void setTargetFolder(String targetFolder) {
-        this.targetFolder = targetFolder;
+    public void setTargetFolderPath(String targetFolderPath) {
+        this.targetFolderPath = targetFolderPath;
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Bundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Bundle.java
@@ -305,8 +305,8 @@ public class Bundle {
         this.loadingMode = loadingMode;
     }
 
-    public String getTargetFolder(){
-        return projectInfo.getTargetFolder();
+    public String getTargetFolderPath(){
+        return projectInfo.getTargetFolderPath();
     }
 
     /**

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilder.java
@@ -64,9 +64,9 @@ public class FolderEntityBuilder implements EntityBuilder {
         return entity;
     }
 
-    private List<Entity> buildEntities(Map<String, Folder> entities, BundleType bundleType, Document document, String targetFolder) {
+    private List<Entity> buildEntities(Map<String, Folder> entities, BundleType bundleType, Document document, String targetFolderPath) {
         // no folder has to be added to environment bundle
-        if ((entities.isEmpty() && StringUtils.isBlank(targetFolder)) || bundleType == ENVIRONMENT) {
+        if ((entities.isEmpty() && StringUtils.isBlank(targetFolderPath)) || bundleType == ENVIRONMENT) {
             return Collections.emptyList();
         }
         Map<Folder, Collection<Folder>> folderChildrenMap = new HashMap<>();
@@ -74,23 +74,22 @@ public class FolderEntityBuilder implements EntityBuilder {
         if (rootFolder == null) {
             throw new EntityBuilderException("Could not locate root folder.");
         }
-        String targetFolderPath = null;
-        if (StringUtils.isNotBlank(targetFolder) && rootFolder != Folder.ROOT_FOLDER) {
+
+        if (StringUtils.isNotBlank(targetFolderPath) && rootFolder != Folder.ROOT_FOLDER) {
             Folder bundleTargetFolder = rootFolder;
-            targetFolderPath =  targetFolder + "/";
             bundleTargetFolder.setId(idGenerator.generate());
-            bundleTargetFolder.setName(targetFolder);
+            bundleTargetFolder.setName(targetFolderPath);
             bundleTargetFolder.setParentFolder(Folder.ROOT_FOLDER);
-            bundleTargetFolder.setPath(targetFolderPath);
-            entities.put(targetFolderPath , bundleTargetFolder);
+            bundleTargetFolder.setPath(targetFolderPath + "/");
+            entities.put(bundleTargetFolder.getPath() , bundleTargetFolder);
             rootFolder = Folder.ROOT_FOLDER;
             entities.put("", rootFolder);
-
         } else {
             rootFolder.setId(Folder.ROOT_FOLDER_ID);
             rootFolder.setName(Folder.ROOT_FOLDER_NAME);
             entities.put("", rootFolder);
         }
+
         entities.values().forEach(folder -> addFolder(folder, folderChildrenMap));
         Stream<Folder> folderStream = Stream.of(rootFolder).flatMap(f -> expand(f, folderChildrenMap));
 
@@ -106,7 +105,7 @@ public class FolderEntityBuilder implements EntityBuilder {
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
         Map<String, Folder> folderMap = Optional.ofNullable(bundle.getFolders()).orElse(Collections.emptyMap());
-        return buildEntities(folderMap, bundleType, document, bundle.getTargetFolder());
+        return buildEntities(folderMap, bundleType, document, bundle.getTargetFolderPath());
     }
 
     @Override

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
@@ -68,12 +68,14 @@ public class ServiceEntityBuilder implements EntityBuilder {
 
     private Entity buildServiceEntity(Bundle bundle, Service service, Document document) {
         AnnotatedEntity annotatedEntity = bundle instanceof AnnotatedBundle ? ((AnnotatedBundle) bundle).getAnnotatedEntity() : null;
-        String servicePath = EntityBuilderHelper.getPath(service.getParentFolder(), PathUtils.extractName(service.getName()));
-        servicePath = CharacterBlacklistUtil.decodePath(servicePath);
-        String baseName = PathUtils.extractName(servicePath);
-        String basePath = PathUtils.extractPath(servicePath);
+
+        final String serviceOriginalPath = service.getName();
+        String servicePathWithTargetFolder = EntityBuilderHelper.getPath(service.getParentFolder(), PathUtils.extractName(service.getName()));
+        servicePathWithTargetFolder = CharacterBlacklistUtil.decodePath(servicePathWithTargetFolder);
+        String baseName = PathUtils.extractName(servicePathWithTargetFolder);
+        String basePath = PathUtils.extractPath(servicePathWithTargetFolder);
         String uniqueName = baseName;
-        String uniqueServicePath = servicePath;
+        String uniqueServicePath = servicePathWithTargetFolder;
         boolean isRedeployableBundle = false;
         if (annotatedEntity != null) {
             isRedeployableBundle = annotatedEntity.isRedeployable();
@@ -158,7 +160,7 @@ public class ServiceEntityBuilder implements EntityBuilder {
         }
 
         serviceElement.appendChild(resourcesElement);
-        Entity entity = EntityBuilderHelper.getEntityWithPathMapping(SERVICE_TYPE, servicePath, uniqueServicePath, id,
+        Entity entity = EntityBuilderHelper.getEntityWithPathMapping(SERVICE_TYPE, serviceOriginalPath, uniqueServicePath, id,
                 serviceElement, policy.isHasRouting(), service);
         if (isRedeployableBundle) {
             entity.setMappingAction(MappingActions.NEW_OR_UPDATE);

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildDeploymentBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildDeploymentBundleTask.java
@@ -14,7 +14,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.*;
@@ -36,7 +35,7 @@ public class BuildDeploymentBundleTask extends DefaultTask {
     private DirectoryProperty from;
     private DirectoryProperty into;
     private ConfigurableFileCollection dependencies;
-    private Property<String> targetFolder;
+    private Property<String> targetFolderPath;
 
     /**
      * Creates a new BuildBundle task to build a bundle from local source files
@@ -45,7 +44,7 @@ public class BuildDeploymentBundleTask extends DefaultTask {
     public BuildDeploymentBundleTask() {
         into = newOutputDirectory();
         from = newInputDirectory();
-        targetFolder = getProject().getObjects().property(String.class);
+        targetFolderPath = getProject().getObjects().property(String.class);
         dependencies = getProject().files();
     }
 
@@ -62,8 +61,8 @@ public class BuildDeploymentBundleTask extends DefaultTask {
 
     @Input
     @Optional
-    public Property<String> getTargetFolder(){
-        return targetFolder;
+    public Property<String> getTargetFolderPath(){
+        return targetFolderPath;
     }
 
     @InputFiles
@@ -76,8 +75,8 @@ public class BuildDeploymentBundleTask extends DefaultTask {
         BundleFileBuilder bundleFileBuilder = InjectionRegistry.getInjector().getInstance(BundleFileBuilder.class);
         final ProjectInfo projectInfo = new ProjectInfo(getProject().getName(), getProject().getGroup().toString(),
                 getProject().getVersion().toString(), null);
-        if(targetFolder.isPresent()){
-            projectInfo.setTargetFolder(targetFolder.get());
+        if(targetFolderPath.isPresent()){
+            projectInfo.setTargetFolderPath(targetFolderPath.get());
         }
         final List<DependentBundle> dependentBundles = getDependentBundles(dependencies.getFiles());
         bundleFileBuilder.buildBundle(from.isPresent() ? from.getAsFile().get() : null, into.getAsFile().get(),

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/CAGatewayDeveloper.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/CAGatewayDeveloper.java
@@ -21,7 +21,6 @@ import org.gradle.api.provider.Provider;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.function.Supplier;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -95,7 +94,7 @@ public class CAGatewayDeveloper implements Plugin<Project> {
                 return dir.getAsFile().exists() ? dir : null;
             }));
             t.getInto().set(pluginConfig.getBuiltBundleDir());
-            t.getTargetFolder().set(pluginConfig.getTargetFolder());
+            t.getTargetFolderPath().set(pluginConfig.getTargetFolderPath());
             t.getDependencies().setFrom(project.getConfigurations().getByName(BUNDLE_CONFIGURATION));
         });
     }

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/GatewayDeveloperPluginConfig.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/GatewayDeveloperPluginConfig.java
@@ -15,7 +15,7 @@ import java.util.Map;
 public class GatewayDeveloperPluginConfig {
 
     private final DirectoryProperty solutionDir;
-    private Property<String> targetFolder;
+    private Property<String> targetFolderPath;
     private DirectoryProperty builtBundleDir;
     private DirectoryProperty builtEnvironmentBundleDir;
     private final Property<Boolean> detemplatizeDeploymentBundles;
@@ -25,7 +25,7 @@ public class GatewayDeveloperPluginConfig {
 
     public GatewayDeveloperPluginConfig(Project project, EnvironmentConfig environmentConfig) {
         solutionDir = project.getLayout().directoryProperty();
-        targetFolder = project.getObjects().property(String.class);
+        targetFolderPath = project.getObjects().property(String.class);
         builtBundleDir = project.getLayout().directoryProperty();
         builtEnvironmentBundleDir = project.getLayout().directoryProperty();
         detemplatizeDeploymentBundles = project.getObjects().property(Boolean.class);
@@ -57,7 +57,7 @@ public class GatewayDeveloperPluginConfig {
         return environmentConfig;
     }
 
-    public Property<String> getTargetFolder() {
-        return targetFolder;
+    public Property<String> getTargetFolderPath() {
+        return targetFolderPath;
     }
 }


### PR DESCRIPTION

## Description  
GatewaySourceConfig.**targetFolder** property name is not in sync with the GatewayExportConfig.folderPath property. 
Changing it to **targetFolderPath**.

## Checklist
- [x] Pull Request Created
- [ ] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
