### PR TITLE
NORALLY: using the fqname for maintaining the unsupported-entities in config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - openjdk8
 script:
-  - ./gradlew clean build
+  - ./gradlew clean build --stacktrace
 branches:
   only:
   - master

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/UnsupportedGatewayEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/UnsupportedGatewayEntity.java
@@ -2,11 +2,15 @@ package com.ca.apim.gateway.cagatewayconfig.beans;
 
 import com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile;
 import com.ca.apim.gateway.cagatewayconfig.config.spec.EnvironmentType;
+import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Element;
 
 import javax.inject.Named;
+
+import java.io.File;
 
 import static com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile.FileType.JSON_YAML;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
@@ -18,6 +22,8 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 public class UnsupportedGatewayEntity extends GatewayEntity {
     private String type;
     private String id;
+    private boolean excluded;
+
     @JsonIgnore
     private Element element;
 
@@ -37,11 +43,36 @@ public class UnsupportedGatewayEntity extends GatewayEntity {
         this.type = type;
     }
 
+    public void setExcluded(boolean excluded) {
+        this.excluded = excluded;
+    }
+
+    public boolean isExcluded() {
+        return excluded;
+    }
+
     public Element getElement() {
         return element;
     }
 
     public void setElement(Element element) {
         this.element = element;
+    }
+
+    @JsonIgnore
+    public String getMappingValue() {
+        return getMappingValue(getType(), getName());
+    }
+
+    public void postLoad(String entityKey, Bundle bundle, @Nullable File rootFolder, IdGenerator idGenerator) {
+        final String prefix = getType() + "/";
+        if (entityKey.startsWith(prefix)) {
+            setName(entityKey.substring(prefix.length()));
+        }
+    }
+
+    @JsonIgnore
+    public static String getMappingValue(final String type, final String name) {
+        return type + "/" + name;
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/UnsupportedGatewayEntity.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/UnsupportedGatewayEntity.java
@@ -66,9 +66,7 @@ public class UnsupportedGatewayEntity extends GatewayEntity {
 
     public void postLoad(String entityKey, Bundle bundle, @Nullable File rootFolder, IdGenerator idGenerator) {
         final String prefix = getType() + "/";
-        if (entityKey.startsWith(prefix)) {
-            setName(entityKey.substring(prefix.length()));
-        }
+        setName(entityKey.startsWith(prefix) ? entityKey.substring(prefix.length()) : entityKey);
     }
 
     @JsonIgnore

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -353,7 +353,7 @@ public class BundleEntityBuilder {
                                 return dependency.getName().equals(PathUtils.extractName(e.getKey())) && dependency.getType().equals(gatewayEntity.getType());
                             }).findFirst();
             Map entityMap = annotatedBundle.getUnsupportedEntities();
-            optionalGatewayEntity.ifPresent(e -> entityMap.put(e.getKey(), e.getValue()));
+            optionalGatewayEntity.ifPresent(e -> entityMap.put(e.getValue().getMappingValue(), e.getValue()));
         }
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/UnsupportedEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/UnsupportedEntityBuilder.java
@@ -19,20 +19,16 @@ public class UnsupportedEntityBuilder implements EntityBuilder {
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
         List<Entity> unsupportedEntities = new ArrayList<>();
         Map<String, UnsupportedGatewayEntity> unsupportedGatewayEntityMap = bundle.getUnsupportedEntities();
-        if (bundleType == ENVIRONMENT) {
-            unsupportedGatewayEntityMap.entrySet().forEach(entry -> {
-                UnsupportedGatewayEntity unsupportedGatewayEntity = entry.getValue();
-                Element resourceElement = (Element) document.adoptNode(unsupportedGatewayEntity.getElement());
-                unsupportedEntities.add(EntityBuilderHelper.getEntityWithNameMapping(unsupportedGatewayEntity.getType(),
-                        unsupportedGatewayEntity.getName(), unsupportedGatewayEntity.getId(), resourceElement));
-            });
-        } else {
-            unsupportedGatewayEntityMap.entrySet().forEach(entry -> {
-                UnsupportedGatewayEntity unsupportedGatewayEntity = entry.getValue();
-                unsupportedEntities.add(EntityBuilderHelper.getEntityWithOnlyMapping(unsupportedGatewayEntity.getType(), unsupportedGatewayEntity.getName(),
-                        unsupportedGatewayEntity.getId()));
-            });
-        }
+        unsupportedGatewayEntityMap.forEach((key, value) -> {
+            if (bundleType != ENVIRONMENT || value.isExcluded()) {
+                unsupportedEntities.add(EntityBuilderHelper.getEntityWithOnlyMapping(value.getType(), value.getName()
+                        , value.getId()));
+            } else {
+                Element resourceElement = (Element) document.adoptNode(value.getElement());
+                unsupportedEntities.add(EntityBuilderHelper.getEntityWithNameMapping(value.getType(), value.getName()
+                        , value.getId(), resourceElement));
+            }
+        });
         return unsupportedEntities;
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/UnsupportedEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/UnsupportedEntityBuilder.java
@@ -24,12 +24,12 @@ public class UnsupportedEntityBuilder implements EntityBuilder {
                 UnsupportedGatewayEntity unsupportedGatewayEntity = entry.getValue();
                 Element resourceElement = (Element) document.adoptNode(unsupportedGatewayEntity.getElement());
                 unsupportedEntities.add(EntityBuilderHelper.getEntityWithNameMapping(unsupportedGatewayEntity.getType(),
-                        entry.getKey(), unsupportedGatewayEntity.getId(), resourceElement));
+                        unsupportedGatewayEntity.getName(), unsupportedGatewayEntity.getId(), resourceElement));
             });
         } else {
             unsupportedGatewayEntityMap.entrySet().forEach(entry -> {
                 UnsupportedGatewayEntity unsupportedGatewayEntity = entry.getValue();
-                unsupportedEntities.add(EntityBuilderHelper.getEntityWithOnlyMapping(unsupportedGatewayEntity.getType(), entry.getKey(),
+                unsupportedEntities.add(EntityBuilderHelper.getEntityWithOnlyMapping(unsupportedGatewayEntity.getType(), unsupportedGatewayEntity.getName(),
                         unsupportedGatewayEntity.getId()));
             });
         }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/BundleEnvironmentValidator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/BundleEnvironmentValidator.java
@@ -115,7 +115,7 @@ class BundleEnvironmentValidator {
                 break;
             default:
                 LOGGER.log(Level.WARNING, "Unsupported gateway entity " + type);
-                UnsupportedGatewayEntity unsupportedGatewayEntity = bundle.getUnsupportedEntities().get(name);
+                UnsupportedGatewayEntity unsupportedGatewayEntity = bundle.getUnsupportedEntities().get(UnsupportedGatewayEntity.getMappingValue(type, name));
                 if (unsupportedGatewayEntity != null && type.equals(unsupportedGatewayEntity.getType())) {
                     entity = unsupportedGatewayEntity;
                 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/EnvironmentConfigurationUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/EnvironmentConfigurationUtils.java
@@ -15,6 +15,7 @@ import com.ca.apim.gateway.cagatewayconfig.beans.GatewayEntity;
 import com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoader;
 import com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoaderRegistry;
 import com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile;
+import com.ca.apim.gateway.cagatewayconfig.config.spec.EnvironmentType;
 import com.ca.apim.gateway.cagatewayconfig.environment.MissingEnvironmentException;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.file.JsonFileUtils;
@@ -117,7 +118,7 @@ public class EnvironmentConfigurationUtils {
             final Map<String, String> environmentValues = new LinkedHashMap<>();
             if (configFolder != null) {
                 final List<Map<String, String>> environmentEntities = environmentBundleData.getReferencedEntities();
-                environmentEntities.stream().forEach(environmentEntitiy -> {
+                environmentEntities.forEach(environmentEntitiy -> {
                     String entityType = environmentEntitiy.get("type");
                     String entityName = environmentEntitiy.get("name");
                     entityName = EnvironmentConfigurationUtils.extractEntityName(entityName);
@@ -138,6 +139,9 @@ public class EnvironmentConfigurationUtils {
                     final File envConfigFile = new File(configFolder, configFileName);
                     if (envConfigFile.exists()) {
                         try {
+                            if (environmentType.equals(UnsupportedGatewayEntity.class.getAnnotation(EnvironmentType.class).value())) {
+                                entityName = entityType + "/" + entityName;
+                            }
                             environmentValues.put(PREFIX_ENV + environmentType + "." + entityName,
                                     loadConfigFromFile(envConfigFile, environmentType, entityName));
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/UnsupportedEntityLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/UnsupportedEntityLoaderTest.java
@@ -64,7 +64,7 @@ public class UnsupportedEntityLoaderTest {
     void testLoadYaml(TemporaryFolder temporaryFolder) throws IOException, SAXException, DocumentParseException {
         DocumentTools documentTools = Mockito.mock(DocumentTools.class);
         UnsupportedEntityLoader unsupportedEntityLoader = new UnsupportedEntityLoader(jsonTools, new IdGenerator(), documentTools);
-        String yaml = "Test MQ:\n" +
+        String yaml = "SSG_ACTIVE/Test MQ:\n" +
                 "  type: \"SSG_ACTIVE\"\n" +
                 "  id: \"101c874561f1c09907094335ae786924\"\n";
         File configFolder = temporaryFolder.createDirectory("config");
@@ -154,9 +154,9 @@ public class UnsupportedEntityLoaderTest {
         gatewayEntity.setId("101c874561f1c09907094335ae786924");
         String yaml = jsonTools.getObjectWriter(JSON).writeValueAsString(gatewayEntity);
         Bundle bundle = new Bundle();
-        unsupportedEntityLoader.load(bundle, "Test MQ", yaml, null);
+        unsupportedEntityLoader.load(bundle, "SSG_ACTIVE/Test MQ", yaml, null);
 
-        UnsupportedGatewayEntity entity = bundle.getUnsupportedEntities().get("Test MQ");
+        UnsupportedGatewayEntity entity = bundle.getUnsupportedEntities().get("SSG_ACTIVE/Test MQ");
         assertEquals(1, bundle.getUnsupportedEntities().size());
         assertEquals("SSG_ACTIVE", entity.getType());
     }
@@ -238,16 +238,17 @@ public class UnsupportedEntityLoaderTest {
         gatewayEntity.setId("101c874561f1c09907094335ae786924");
         String yaml = jsonTools.getObjectWriter(JSON).writeValueAsString(gatewayEntity);
         Bundle bundle = new Bundle();
-        unsupportedEntityLoader.load(bundle, "Test MQ", yaml, configFolder.getPath());
+        unsupportedEntityLoader.load(bundle, "SSG_ACTIVE/Test MQ", yaml, configFolder.getPath());
 
         verifyConfig(bundle);
     }
 
     private void verifyConfig(Bundle bundle) {
-        UnsupportedGatewayEntity entity = bundle.getUnsupportedEntities().get("Test MQ");
+        UnsupportedGatewayEntity entity = bundle.getUnsupportedEntities().get("SSG_ACTIVE/Test MQ");
         Element element = entity.getElement();
         assertEquals(1, bundle.getUnsupportedEntities().size());
         assertEquals("SSG_ACTIVE", entity.getType());
+        assertEquals("Test MQ", entity.getName());
         assertEquals("l7:ActiveConnector", element.getTagName());
     }
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/bundle/BundleBuilder.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/bundle/BundleBuilder.java
@@ -128,6 +128,10 @@ public class BundleBuilder {
         entity.setName(getSingleChildElement(element, NAME).getTextContent());
         entity.setElement(element);
 
+        if ("SERVER_MODULE_FILE".equals(entity.getType())) {
+            entity.setExcluded(true);
+        }
+
         LOGGER.log(Level.WARNING, "Recording the {0}/{1} with id: {2} as unsupported entity",
                 new Object[] {entity.getType(), entity.getName(), entity.getId()});
         bundle.addEntity(entity);

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/bundle/BundleBuilder.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/bundle/BundleBuilder.java
@@ -132,7 +132,7 @@ public class BundleBuilder {
             entity.setExcluded(true);
         }
 
-        LOGGER.log(Level.WARNING, "Recording the {0}/{1} with id: {2} as unsupported entity",
+        LOGGER.log(Level.INFO, "Recording the {0}/{1} with id: {2} as unsupported entity",
                 new Object[] {entity.getType(), entity.getName(), entity.getId()});
         bundle.addEntity(entity);
     }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/bundle/BundleBuilder.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/bundle/BundleBuilder.java
@@ -128,6 +128,8 @@ public class BundleBuilder {
         entity.setName(getSingleChildElement(element, NAME).getTextContent());
         entity.setElement(element);
 
+        LOGGER.log(Level.WARNING, "Recording the {0}/{1} with id: {2} as unsupported entity",
+                new Object[] {entity.getType(), entity.getName(), entity.getId()});
         bundle.addEntity(entity);
     }
 }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
@@ -1,8 +1,10 @@
 package com.ca.apim.gateway.cagatewayexport.tasks.explode.writer;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
+import com.ca.apim.gateway.cagatewayconfig.beans.EntityUtils;
 import com.ca.apim.gateway.cagatewayconfig.beans.UnsupportedGatewayEntity;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
+import com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import io.github.glytching.junit.extension.folder.TemporaryFolder;
@@ -15,6 +17,9 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -22,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class UnsupportedEntityWriterTest {
 
     @Test
-    void testWrite(final TemporaryFolder temporaryFolder) throws DocumentParseException {
+    void testWrite(final TemporaryFolder temporaryFolder) throws DocumentParseException, IOException {
         UnsupportedEntityWriter writer = new UnsupportedEntityWriter(DocumentFileUtils.INSTANCE, DocumentTools.INSTANCE);
         String entityName = "Test MQ";
         String xml = "<l7:Items xmlns:l7=\"http://ns.l7tech.com/2010/04/gateway-management\"><l7:Item>\n" +
@@ -106,5 +111,12 @@ public class UnsupportedEntityWriterTest {
 
         File unsupportedEntitiesXml = new File(configFolder, "unsupported-entities.xml");
         assertTrue(unsupportedEntitiesXml.exists());
+
+        WriterHelper.write(bundle, temporaryFolder.getRoot(), EntityUtils.createEntityInfo(UnsupportedGatewayEntity.class), DocumentFileUtils.INSTANCE, JsonTools.INSTANCE);
+        File unsupportedEntitiesYml = new File(configFolder, "unsupported-entities.yml");
+        assertTrue(unsupportedEntitiesYml.exists());
+
+        final String ymlContent = new String(Files.readAllBytes(unsupportedEntitiesYml.toPath()), Charset.forName("utf-8"));
+        assertTrue(ymlContent.contains("SSG_ACTIVE/Test MQ:"));
     }
 }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.Objects;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(TemporaryFolderExtension.class)
@@ -115,11 +116,10 @@ public class UnsupportedEntityWriterTest {
         assertTrue(unsupportedEntitiesXml.exists());
 
         EntityUtils.GatewayEntityInfo gatewayEntityInfo = EntityUtils.createEntityInfo(UnsupportedGatewayEntity.class);
-        System.out.println("Gateway entity Info for unsupported entity: " + gatewayEntityInfo);
-        WriterHelper.write(bundle, temporaryFolder.getRoot(), gatewayEntityInfo, DocumentFileUtils.INSTANCE, JsonTools.INSTANCE);
+        assertEquals("unsupported-entities", gatewayEntityInfo.getFileName());
+        WriterHelper.writeFile(temporaryFolder.getRoot(), DocumentFileUtils.INSTANCE, JsonTools.INSTANCE,
+                bundle.getUnsupportedEntities(), gatewayEntityInfo.getFileName(), UnsupportedGatewayEntity.class);
 
-        configFolder = new File(temporaryFolder.getRoot(), "config");
-        assertTrue(configFolder.exists());
         File unsupportedEntitiesYml = new File(configFolder, "unsupported-entities.yml");
         assertTrue(unsupportedEntitiesYml.exists());
 

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
@@ -114,13 +114,12 @@ public class UnsupportedEntityWriterTest {
         File unsupportedEntitiesXml = new File(configFolder, "unsupported-entities.xml");
         assertTrue(unsupportedEntitiesXml.exists());
 
-        try {
-            EntityUtils.GatewayEntityInfo gatewayEntityInfo = EntityUtils.createEntityInfo(UnsupportedGatewayEntity.class);
-            System.out.println("Gateway entity Info for unsupported entity: " + gatewayEntityInfo);
-            WriterHelper.write(bundle, temporaryFolder.getRoot(), gatewayEntityInfo, DocumentFileUtils.INSTANCE, JsonTools.INSTANCE);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        EntityUtils.GatewayEntityInfo gatewayEntityInfo = EntityUtils.createEntityInfo(UnsupportedGatewayEntity.class);
+        System.out.println("Gateway entity Info for unsupported entity: " + gatewayEntityInfo);
+        WriterHelper.write(bundle, temporaryFolder.getRoot(), gatewayEntityInfo, DocumentFileUtils.INSTANCE, JsonTools.INSTANCE);
+
+        configFolder = new File(temporaryFolder.getRoot(), "config");
+        assertTrue(configFolder.exists());
         File unsupportedEntitiesYml = new File(configFolder, "unsupported-entities.yml");
         assertTrue(unsupportedEntitiesYml.exists());
 

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
@@ -5,6 +5,7 @@ import com.ca.apim.gateway.cagatewayconfig.beans.EntityUtils;
 import com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider;
 import com.ca.apim.gateway.cagatewayconfig.beans.UnsupportedGatewayEntity;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
+import com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
@@ -129,9 +130,11 @@ public class UnsupportedEntityWriterTest {
 
         bundle.getUnsupportedEntities().put("Test MQ", unsupportedGatewayEntity);
 
+        final JsonTools jsonTools = new JsonTools(FileUtils.INSTANCE);
         EntityUtils.GatewayEntityInfo gatewayEntityInfo = EntityUtils.createEntityInfo(UnsupportedGatewayEntity.class);
         assertEquals("unsupported-entities", gatewayEntityInfo.getFileName());
-        WriterHelper.writeFile(temporaryFolder.getRoot(), DocumentFileUtils.INSTANCE, JsonTools.INSTANCE,
+        assertEquals(".yml", jsonTools.getFileExtension());
+        WriterHelper.writeFile(temporaryFolder.getRoot(), DocumentFileUtils.INSTANCE, jsonTools,
                 bundle.getUnsupportedEntities(), gatewayEntityInfo.getFileName(), UnsupportedGatewayEntity.class);
 
         File configFolder = new File(temporaryFolder.getRoot(), "config");

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
@@ -139,7 +139,7 @@ public class UnsupportedEntityWriterTest {
 
         File configFolder = new File(temporaryFolder.getRoot(), "config");
         assertTrue(configFolder.exists());
-        File unsupportedEntitiesYml = new File(configFolder, gatewayEntityInfo.getFileName() + JsonTools.INSTANCE.getFileExtension());
+        File unsupportedEntitiesYml = new File(configFolder, gatewayEntityInfo.getFileName() + jsonTools.getFileExtension());
         assertTrue(unsupportedEntitiesYml.exists());
 
         final String ymlContent = new String(Files.readAllBytes(unsupportedEntitiesYml.toPath()), StandardCharsets.UTF_8);

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
@@ -20,6 +20,7 @@ import org.w3c.dom.NodeList;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Objects;
 
@@ -138,7 +139,7 @@ public class UnsupportedEntityWriterTest {
         File unsupportedEntitiesYml = new File(configFolder, gatewayEntityInfo.getFileName() + JsonTools.INSTANCE.getFileExtension());
         assertTrue(unsupportedEntitiesYml.exists());
 
-        final String ymlContent = new String(Files.readAllBytes(unsupportedEntitiesYml.toPath()), Charset.forName("utf-8"));
-        assertTrue(ymlContent.contains("SSG_ACTIVE/Test MQ:"));
+        final String ymlContent = new String(Files.readAllBytes(unsupportedEntitiesYml.toPath()), StandardCharsets.UTF_8);
+        assertEquals("SSG_ACTIVE/Test MQ:", ymlContent.split("\n")[0]);
     }
 }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
@@ -2,6 +2,7 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode.writer;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.EntityUtils;
+import com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider;
 import com.ca.apim.gateway.cagatewayconfig.beans.UnsupportedGatewayEntity;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools;
@@ -20,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -112,7 +114,13 @@ public class UnsupportedEntityWriterTest {
         File unsupportedEntitiesXml = new File(configFolder, "unsupported-entities.xml");
         assertTrue(unsupportedEntitiesXml.exists());
 
-        WriterHelper.write(bundle, temporaryFolder.getRoot(), EntityUtils.createEntityInfo(UnsupportedGatewayEntity.class), DocumentFileUtils.INSTANCE, JsonTools.INSTANCE);
+        try {
+            EntityUtils.GatewayEntityInfo gatewayEntityInfo = EntityUtils.createEntityInfo(UnsupportedGatewayEntity.class);
+            System.out.println("Gateway entity Info for unsupported entity: " + gatewayEntityInfo);
+            WriterHelper.write(bundle, temporaryFolder.getRoot(), gatewayEntityInfo, DocumentFileUtils.INSTANCE, JsonTools.INSTANCE);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         File unsupportedEntitiesYml = new File(configFolder, "unsupported-entities.yml");
         assertTrue(unsupportedEntitiesYml.exists());
 

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/UnsupportedEntityWriterTest.java
@@ -114,13 +114,28 @@ public class UnsupportedEntityWriterTest {
 
         File unsupportedEntitiesXml = new File(configFolder, "unsupported-entities.xml");
         assertTrue(unsupportedEntitiesXml.exists());
+    }
+
+    @Test
+    public void testYamlWrite(final TemporaryFolder temporaryFolder) throws IOException {
+        String entityName = "Test MQ";
+
+        Bundle bundle = new Bundle();
+        UnsupportedGatewayEntity unsupportedGatewayEntity = new UnsupportedGatewayEntity();
+        unsupportedGatewayEntity.setName(entityName);
+        unsupportedGatewayEntity.setId("testId");
+        unsupportedGatewayEntity.setType("SSG_ACTIVE");
+
+        bundle.getUnsupportedEntities().put("Test MQ", unsupportedGatewayEntity);
 
         EntityUtils.GatewayEntityInfo gatewayEntityInfo = EntityUtils.createEntityInfo(UnsupportedGatewayEntity.class);
         assertEquals("unsupported-entities", gatewayEntityInfo.getFileName());
         WriterHelper.writeFile(temporaryFolder.getRoot(), DocumentFileUtils.INSTANCE, JsonTools.INSTANCE,
                 bundle.getUnsupportedEntities(), gatewayEntityInfo.getFileName(), UnsupportedGatewayEntity.class);
 
-        File unsupportedEntitiesYml = new File(configFolder, "unsupported-entities.yml");
+        File configFolder = new File(temporaryFolder.getRoot(), "config");
+        assertTrue(configFolder.exists());
+        File unsupportedEntitiesYml = new File(configFolder, gatewayEntityInfo.getFileName() + JsonTools.INSTANCE.getFileExtension());
         assertTrue(unsupportedEntitiesYml.exists());
 
         final String ymlContent = new String(Files.readAllBytes(unsupportedEntitiesYml.toPath()), Charset.forName("utf-8"));


### PR DESCRIPTION
## Description  
1. Name is used to qualify the unsupported-entities in the config file. It is not sufficient enough. We must use (type/name) as a fully qualified mapping value so that there will not be any name conflicts across gateway types.
2. Exclude property is added to the config entity so that the user can choose whether it needs to be included in the bundle or not. The default value is false.
3. When exclude property is set to `true`, mapping action is set to `NewOrExisting` with `FailOnNew="true"` flag.
4. Fixing issue - unsupported entities were not being included in the Full Bundle.

## Checklist
- [x] Pull Request Created
- [x] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
