### PR TITLE
NORALLY: introducing a property to configure entity default mapping action

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleDocumentBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleDocumentBuilder.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.buildAndAppendPropertiesElement;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
-import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions.NEW_OR_UPDATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
 
 @Singleton
@@ -45,7 +44,13 @@ public class BundleDocumentBuilder {
     }
 
     private Element buildEntityMapping(final Entity entity, final Document document) {
-        final Element mapping = createElementWithAttributes(document, MAPPING, ImmutableMap.of(ATTRIBUTE_ACTION, entity.getMappingAction() == null ? NEW_OR_UPDATE : entity.getMappingAction(), ATTRIBUTE_SRCID, entity.getId(), ATTRIBUTE_TYPE, entity.getType()));
+        final Element mapping = createElementWithAttributes(document, MAPPING, ImmutableMap.of(
+                ATTRIBUTE_ACTION,
+                entity.getMappingAction() == null ? EntityBuilderHelper.getDefaultEntityMappingAction() : entity.getMappingAction(),
+                ATTRIBUTE_SRCID,
+                entity.getId(),
+                ATTRIBUTE_TYPE,
+                entity.getType()));
         buildAndAppendPropertiesElement(entity.getMappingProperties(), document, mapping);
 
         return mapping;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleMetadataBuilder.java
@@ -9,6 +9,7 @@ package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
+import com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
@@ -60,7 +61,8 @@ public class BundleMetadataBuilder {
             }
             builder.dependencies(annotatedBundle.getDependentBundles());
             builder.tags(annotatedEntity.getTags());
-            builder.redeployable(annotatedEntity.isRedeployable() || !isBundleContainsSharedEntity(annotatedBundle));
+            builder.redeployable(annotatedEntity.isRedeployable() ||
+                    (MappingActions.NEW_OR_UPDATE.equals(EntityBuilderHelper.getDefaultEntityMappingAction()) && !isBundleContainsSharedEntity(annotatedBundle)));
             builder.l7Template(annotatedEntity.isL7Template());
             builder.hasRouting(hasRoutingAssertion(dependentEntities));
 
@@ -95,7 +97,7 @@ public class BundleMetadataBuilder {
             tags.add(projectInfo.getConfigName());
         }
         builder.tags(tags);
-        builder.redeployable(true);
+        builder.redeployable(MappingActions.NEW_OR_UPDATE.equals(EntityBuilderHelper.getDefaultEntityMappingAction()));
         builder.hasRouting(false);
         builder.definedEntities(getEnvironmentDependenciesMetadata(entities));
 
@@ -113,7 +115,7 @@ public class BundleMetadataBuilder {
         BundleMetadata.Builder builder = new BundleMetadata.Builder(BUNDLE_TYPE_ALL, projectInfo.getName(), projectInfo.getName(), projectInfo.getGroupName(), projectInfo.getVersion());
         builder.description(StringUtils.EMPTY);
         builder.tags(Collections.emptyList());
-        builder.redeployable(true);
+        builder.redeployable(MappingActions.NEW_OR_UPDATE.equals(EntityBuilderHelper.getDefaultEntityMappingAction()));
         builder.hasRouting(hasRoutingAssertion(entities));
         final Collection<Metadata> referencedEntities = getEnvironmentDependenciesMetadata(entities);
         builder.referencedEntities(referencedEntities);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -9,7 +9,6 @@ package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.IdValidator;
-import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions;
 import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
 import com.google.common.collect.ImmutableMap;
@@ -180,15 +179,17 @@ public class EncassEntityBuilder implements EntityBuilder {
         final Map<String, Object> properties = Optional.ofNullable(encass.getProperties()).orElse(new HashMap<>());
         properties.putIfAbsent(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
         buildAndAppendPropertiesElement(properties, document, encassAssertionElement);
-        Entity entity = getEntityWithNameMapping(ENCAPSULATED_ASSERTION_TYPE, name, uniqueEncassName, id, encassAssertionElement, guid, encass);
 
-        if (isRedeployableBundle || !isShared) {
+        final Entity entity = getEntityWithNameMapping(ENCAPSULATED_ASSERTION_TYPE, name, uniqueEncassName, id, encassAssertionElement, guid, encass);
+        if (isRedeployableBundle) {
             entity.setMappingAction(MappingActions.NEW_OR_UPDATE);
-        } else {
+        } else if (isShared) {
             entity.setMappingAction(MappingActions.NEW_OR_EXISTING);
+        } else {
+            entity.setMappingAction(EntityBuilderHelper.getDefaultEntityMappingAction());
         }
-        return entity;
 
+        return entity;
     }
 
     private Element buildResults(Encass encass, Document document) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelper.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelper.java
@@ -12,22 +12,46 @@ import com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions;
 import com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties;
 import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import org.w3c.dom.Element;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
-import static com.ca.apim.gateway.cagatewayconfig.beans.Folder.ROOT_FOLDER_ID;
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.Entity.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions.ALWAYS_CREATE_NEW;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions.NEW_OR_EXISTING;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions.NEW_OR_UPDATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties.*;
 
 class EntityBuilderHelper {
+    // TODO: reconsider the default value. NewOrExisting is the safest and acceptable action for most of the customer's scenarios.
+    private static final String DEFAULT_ENTITY_MAPPING_ACTION = "NewOrUpdate";
+    private static final String DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY = "com.ca.apim.build.defaultEntityMappingAction";
+    private static String defaultEntityMappingAction;
 
     private EntityBuilderHelper() {
+    }
+
+    @VisibleForTesting
+    static void resetDefaultEntityMappingAction(String value) {
+        defaultEntityMappingAction = null;
+        System.setProperty(DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY, value != null ? value : DEFAULT_ENTITY_MAPPING_ACTION);
+    }
+
+    static String getDefaultEntityMappingAction() {
+        if (defaultEntityMappingAction == null) {
+            String action = System.getProperty(DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY);
+            if (action == null ||
+                    !Pattern.matches(NEW_OR_EXISTING + "|" + NEW_OR_UPDATE + "|" + ALWAYS_CREATE_NEW, action)) {
+                action = DEFAULT_ENTITY_MAPPING_ACTION;
+            }
+            defaultEntityMappingAction = action;
+        }
+
+        return defaultEntityMappingAction;
     }
 
     static Entity getEntityWithOnlyMapping(String entityType, String name, String id) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelper.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelper.java
@@ -18,17 +18,18 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.Entity.*;
-import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions.ALWAYS_CREATE_NEW;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions.NEW_OR_EXISTING;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions.NEW_OR_UPDATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties.*;
 
 class EntityBuilderHelper {
+    private static final Logger LOGGER = Logger.getLogger(EntityBuilderHelper.class.getName());
     // TODO: reconsider the default value. NewOrExisting is the safest and acceptable action for most of the customer's scenarios.
-    private static final String DEFAULT_ENTITY_MAPPING_ACTION = "NewOrUpdate";
+    private static final String DEFAULT_ENTITY_MAPPING_ACTION = NEW_OR_UPDATE;
     private static final String DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY = "com.ca.apim.build.defaultEntityMappingAction";
     private static String defaultEntityMappingAction;
 
@@ -45,10 +46,11 @@ class EntityBuilderHelper {
         if (defaultEntityMappingAction == null) {
             String action = System.getProperty(DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY);
             if (action == null ||
-                    !Pattern.matches(NEW_OR_EXISTING + "|" + NEW_OR_UPDATE + "|" + ALWAYS_CREATE_NEW, action)) {
+                    !Pattern.matches(NEW_OR_EXISTING + "|" + NEW_OR_UPDATE, action)) {
                 action = DEFAULT_ENTITY_MAPPING_ACTION;
             }
             defaultEntityMappingAction = action;
+            LOGGER.info("Using default entity mapping action as " + defaultEntityMappingAction);
         }
 
         return defaultEntityMappingAction;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -243,11 +243,15 @@ public class PolicyEntityBuilder implements EntityBuilder {
         policyElement.appendChild(resourcesElement);
         Entity entity = EntityBuilderHelper.getEntityWithPathMapping(EntityTypes.POLICY_TYPE,
                 policy.getPath(), policyNameWithPath, policy.getId(), policyElement, policy.isHasRouting(), policy);
-        if (isRedeployableBundle || !policy.isParentEntityShared()) {
+
+        if (isRedeployableBundle) {
             entity.setMappingAction(MappingActions.NEW_OR_UPDATE);
-        } else {
+        } else if (policy.isParentEntityShared()) {
             entity.setMappingAction(MappingActions.NEW_OR_EXISTING);
+        } else {
+            entity.setMappingAction(EntityBuilderHelper.getDefaultEntityMappingAction());
         }
+
         return entity;
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
@@ -163,8 +163,11 @@ public class ServiceEntityBuilder implements EntityBuilder {
         if (isRedeployableBundle) {
             entity.setMappingAction(MappingActions.NEW_OR_UPDATE);
         } else {
+            // TODO: Once we change the default value of entity mapping action to NewOrExisting,
+            //      we should change the below statement to use EntityBundleHelper.getDefaultEntityMappingAction()
             entity.setMappingAction(MappingActions.NEW_OR_EXISTING);
         }
+
         return entity;
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
@@ -163,9 +163,7 @@ public class ServiceEntityBuilder implements EntityBuilder {
         if (isRedeployableBundle) {
             entity.setMappingAction(MappingActions.NEW_OR_UPDATE);
         } else {
-            // TODO: Once we change the default value of entity mapping action to NewOrExisting,
-            //      we should change the below statement to use EntityBundleHelper.getDefaultEntityMappingAction()
-            entity.setMappingAction(MappingActions.NEW_OR_EXISTING);
+            entity.setMappingAction(EntityBuilderHelper.getDefaultEntityMappingAction());
         }
 
         return entity;

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
@@ -548,7 +548,7 @@ class BundleEntityBuilderTest {
         bundle.getServices().put(TEST_SERVICE, service);
 
         AnnotatedBundle annotatedBundle = new AnnotatedBundle(bundle, service.getAnnotatedEntity(), projectInfo);
-        buildAndValidateAnnotatedServiceBundle(bundle, annotatedBundle, TEST_SERVICE, NEW_OR_EXISTING,
+        buildAndValidateAnnotatedServiceBundle(bundle, annotatedBundle, TEST_SERVICE, NEW_OR_UPDATE,
                 TEST_DEP_ENCASS_POLICY, NEW_OR_EXISTING, TEST_DEP_ENCASS, NEW_OR_EXISTING);
     }
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelperTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelperTest.java
@@ -31,8 +31,11 @@ public class EntityBuilderHelperTest {
         Assert.assertTrue(MappingActions.NEW_OR_EXISTING.equals(EntityBuilderHelper.getDefaultEntityMappingAction()) ||
                 MappingActions.NEW_OR_UPDATE.equals(EntityBuilderHelper.getDefaultEntityMappingAction()));
 
-        EntityBuilderHelper.resetDefaultEntityMappingAction(MappingActions.ALWAYS_CREATE_NEW);
-        Assert.assertEquals(MappingActions.ALWAYS_CREATE_NEW, EntityBuilderHelper.getDefaultEntityMappingAction());
+        EntityBuilderHelper.resetDefaultEntityMappingAction(MappingActions.NEW_OR_EXISTING);
+        Assert.assertEquals(MappingActions.NEW_OR_EXISTING, EntityBuilderHelper.getDefaultEntityMappingAction());
+
+        EntityBuilderHelper.resetDefaultEntityMappingAction(MappingActions.NEW_OR_UPDATE);
+        Assert.assertEquals(MappingActions.NEW_OR_UPDATE, EntityBuilderHelper.getDefaultEntityMappingAction());
     }
 
     @Test

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelperTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelperTest.java
@@ -8,14 +8,33 @@ import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class EntityBuilderHelperTest {
+
+    @Before
+    public void beforeTest() {
+        EntityBuilderHelper.resetDefaultEntityMappingAction(null);
+    }
+
+    @Test
+    public void testDefaultEntityMappingAction() {
+        Assert.assertTrue(StringUtils.isNotBlank(EntityBuilderHelper.getDefaultEntityMappingAction()));
+        Assert.assertTrue(MappingActions.NEW_OR_EXISTING.equals(EntityBuilderHelper.getDefaultEntityMappingAction()) ||
+                MappingActions.NEW_OR_UPDATE.equals(EntityBuilderHelper.getDefaultEntityMappingAction()));
+
+        EntityBuilderHelper.resetDefaultEntityMappingAction(MappingActions.ALWAYS_CREATE_NEW);
+        Assert.assertEquals(MappingActions.ALWAYS_CREATE_NEW, EntityBuilderHelper.getDefaultEntityMappingAction());
+    }
+
     @Test
     public void testGetEntityWithMappings() throws DocumentParseException {
         Map<String, Object> mappingProperties = new HashMap<>();


### PR DESCRIPTION
## Description  
Dev-plugin chooses the entity mapping action "**NewOrUpdate**" as default. This can be changed by defining the system property "com.ca.apim.build.defaultEntityMappingAction". With this change, this choice can be made configurable so that policy authors can generate bundles with their own choice of entity mapping action. 

One of the requirements is to generate the bundles with the mapping action as "NewOrExisting". This action is safer when it comes to production deployment.

In addition, corrected the mapping action for SERVICE entity. Earlier, it was NewOrExisting. Now, it is NewOrUpdate.

## Checklist
- [x] Pull Request Created
- [ ] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
