### PR TITLE
Fixing private key issues

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Bundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Bundle.java
@@ -28,6 +28,8 @@ public class Bundle {
 
     // some special things need their own maps
     private final Map<String, SupplierWithIO<InputStream>> certificateFiles = new HashMap<>();
+    private final Map<String, SupplierWithIO<InputStream>> privateKeyFiles = new HashMap<>();
+
     private Set<Bundle> dependencies;
     private FolderTree folderTree;
     private Map<Dependency, List<Dependency>> dependencyMap;
@@ -234,6 +236,14 @@ public class Bundle {
 
     public void putAllPrivateKeys(@NotNull Map<String, PrivateKey> privateKeys) {
         this.getPrivateKeys().putAll(privateKeys);
+    }
+
+    public Map<String, SupplierWithIO<InputStream>> getPrivateKeyFiles() {
+        return privateKeyFiles;
+    }
+
+    public void putAllPrivateKeyFiles(@NotNull Map<String, SupplierWithIO<InputStream>> privateKeys) {
+        this.privateKeyFiles.putAll(privateKeys);
     }
 
     public void putAllSsgActiveConnectors(@NotNull Map<String, SsgActiveConnector> ssgActiveConnectors) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/PrivateKey.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/PrivateKey.java
@@ -132,12 +132,14 @@ public class PrivateKey extends GatewayEntity {
 
     @Override
     public void postLoad(String entityKey, Bundle bundle, File rootFolder, IdGenerator idGenerator) {
-        if (rootFolder != null) {
-            loadPrivateKey(this, new File(rootFolder, "config/privateKeys"), false);
-        }
-
         setAlias(entityKey);
         setKeyStoreType(KeyStoreType.fromName(getKeystore()));
+        if (bundle.getPrivateKeyFiles().get(getAlias()) != null) {
+            setPrivateKeyFile(bundle.getPrivateKeyFiles().get(getAlias()));
+        }
+        if (rootFolder != null && getPrivateKeyFile() == null) {
+            loadPrivateKey(this, new File(rootFolder, "config/privateKeys"), false);
+        }
     }
 
     public static void loadFromDirectory(Collection<PrivateKey> privateKeys, File privateKeysDirectory, boolean failOnMissingKeys) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BuilderConstants.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BuilderConstants.java
@@ -43,6 +43,8 @@ public final class BuilderConstants {
         }
     };
 
+    public static final Predicate<Entity> FILTER_OUT_PRIVATE_KEYS = entity -> !EntityTypes.PRIVATE_KEY_TYPE.equals(entity.getType());
+
     public static final Predicate<Entity> FILTER_NON_ENV_ENTITIES = new Predicate<Entity>() {
         @Override
         public boolean test(Entity entity) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -24,10 +24,8 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.FILTER_ENV_ENTITIES;
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.*;
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.*;
-import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.FILTER_NON_ENV_ENTITIES;
-import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.FILTER_OUT_DEFAULT_LISTEN_PORTS;
 import static com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes.FOLDER_TYPE;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.DELETE_BUNDLE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.INSTALL_BUNDLE_EXTENSION;
@@ -203,7 +201,8 @@ public class BundleEntityBuilder {
      * @return Delete bundle Element for the Annotated Bundle
      */
     private Element createDeleteEnvBundle(final Document document, List<Entity> entities) {
-        List<Entity> filteredEntities = copyFilteredEntitiesForDeleteBundle(entities, FILTER_ENV_ENTITIES.and(FILTER_OUT_DEFAULT_LISTEN_PORTS));
+        List<Entity> filteredEntities = copyFilteredEntitiesForDeleteBundle(entities,
+                FILTER_ENV_ENTITIES.and(FILTER_OUT_DEFAULT_LISTEN_PORTS).and(FILTER_OUT_PRIVATE_KEYS));
         filteredEntities.forEach(e -> e.setMappingAction(MappingActions.DELETE));
         return bundleDocumentBuilder.build(document, filteredEntities);
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/config/loader/PrivateKeyLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/config/loader/PrivateKeyLoader.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2018 CA. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+package com.ca.apim.gateway.cagatewayconfig.config.loader;
+
+import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
+import com.ca.apim.gateway.cagatewayconfig.util.file.SupplierWithIO;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.FileUtils;
+
+import javax.inject.Singleton;
+import java.io.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.findConfigFileOrDir;
+import static org.apache.commons.io.FilenameUtils.getBaseName;
+
+/**
+ * Loads the private keys specified in the 'privateKeys' directory. Private Keys in this directory must end with .p12.
+ */
+@Singleton
+public class PrivateKeyLoader implements EntityLoader {
+
+    @Override
+    public void load(Bundle bundle, File rootDir) {
+        final File privateKeysDir = findConfigFileOrDir(rootDir, "privateKeys");
+        if (privateKeysDir != null && privateKeysDir.exists()) {
+            final String[] privateKeyFiles = privateKeysDir.list();
+            if (privateKeyFiles != null && privateKeyFiles.length > 0) {
+                final Map<String, SupplierWithIO<InputStream>> map = new HashMap<>();
+                Arrays.stream(privateKeyFiles).forEach(privateKey -> {
+                    if (checkPrivateKeyFormat(privateKey)) {
+                        map.put(getBaseName(privateKey),
+                                () -> new FileInputStream(new File(privateKeysDir, privateKey)));
+                    } else {
+                        throw new ConfigLoadException(privateKey + " must be a valid private key extension (.p12).");
+                    }
+                });
+                bundle.putAllPrivateKeyFiles(map);
+            }
+        }
+    }
+
+    @Override
+    public void load(Bundle bundle, String name, String value) {
+        if (checkPrivateKeyFormat(name)) {
+            bundle.getPrivateKeyFiles().put(name.substring(0, name.length() - 4),
+                    () -> new ByteArrayInputStream(Base64.decodeBase64(value)));
+        } else {
+            throw new ConfigLoadException(name + " must be a valid private key extension (.p12).");
+        }
+    }
+
+    @Override
+    public Object loadSingle(String name, File entitiesFile) {
+        if (!checkPrivateKeyFormat(entitiesFile.getName())) {
+            throw new ConfigLoadException(name + " must be a valid private key extension (.p12).");
+        }
+        try {
+            return Base64.encodeBase64String(FileUtils.readFileToByteArray(entitiesFile));
+        } catch (IOException e) {
+            throw new ConfigLoadException("Cannot load private key " + name);
+        }
+    }
+
+    @Override
+    public Map<String, Object> load(File entitiesFile) {
+        throw new ConfigLoadException("Cannot load private keys from " + entitiesFile);
+    }
+
+    private boolean checkPrivateKeyFormat(String certFileName) {
+        return certFileName.toLowerCase().endsWith(".p12");
+    }
+
+    @Override
+    public String getEntityType() {
+        return "PRIVATE_KEY_FILE";
+    }
+}

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/EnvironmentConfigurationUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/EnvironmentConfigurationUtils.java
@@ -36,6 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.PREFIX_ENVIRONMENT;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.CertificateUtils.P12_CERT_FILE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.CertificateUtils.PEM_CERT_FILE_EXTENSION;
 import static com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PREFIX_ENV;
@@ -149,6 +150,15 @@ public class EnvironmentConfigurationUtils {
                                 final File certDataFile = new File(configFolder + "/certificates", entityName + PEM_CERT_FILE_EXTENSION);
                                 environmentValues.put(PREFIX_ENV + "CERTIFICATE_FILE" + "." + entityName + PEM_CERT_FILE_EXTENSION,
                                         loadConfigFromFile(certDataFile, "CERTIFICATE_FILE", entityName));
+                            } else if (EntityTypes.PRIVATE_KEY_TYPE.equals(entityType)) {
+                                final File privateKeysFolder = new File(configFolder, "privateKeys");
+                                if (privateKeysFolder.exists()) {
+                                    File privateKeyFile = new File(privateKeysFolder, entityName + P12_CERT_FILE_EXTENSION);
+                                    if (privateKeyFile.exists()) {
+                                        environmentValues.put(PREFIX_ENV + "PRIVATE_KEY_FILE." + entityName + P12_CERT_FILE_EXTENSION,
+                                                loadConfigFromFile(privateKeyFile, "PRIVATE_KEY_FILE", entityName));
+                                    }
+                                }
                             }
                         } catch (MissingEnvironmentException ex) {
                             LOGGER.log(Level.INFO, "could not find dependent environment entity in the configured folder " + entityName);
@@ -190,6 +200,15 @@ public class EnvironmentConfigurationUtils {
                             final File certDataFile = new File(configFolder + "/certificates", entry.getKey() + PEM_CERT_FILE_EXTENSION);
                             environmentValues.put(PREFIX_ENV + "CERTIFICATE_FILE" + "." + entry.getKey() + PEM_CERT_FILE_EXTENSION,
                                     loadConfigFromFile(certDataFile, "CERTIFICATE_FILE", entry.getKey()));
+                        } else if (EntityTypes.PRIVATE_KEY_TYPE.equals(entityType)) {
+                            final File privateKeysFolder = new File(configFolder, "privateKeys");
+                            if (privateKeysFolder.exists()) {
+                                File privateKeyFile = new File(privateKeysFolder, entry.getKey() + P12_CERT_FILE_EXTENSION);
+                                if (privateKeyFile.exists()) {
+                                    environmentValues.put(PREFIX_ENV + "PRIVATE_KEY_FILE." + entry.getKey() + P12_CERT_FILE_EXTENSION,
+                                            loadConfigFromFile(privateKeyFile, "PRIVATE_KEY_FILE", entry.getKey()));
+                                }
+                            }
                         }
                     });
                 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/CertificateUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/CertificateUtils.java
@@ -32,6 +32,7 @@ import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createE
 public class CertificateUtils {
 
     public static final String PEM_CERT_FILE_EXTENSION = ".pem";
+    public static final String P12_CERT_FILE_EXTENSION = ".p12";
     static final String PEM_CERT_BEGIN_MARKER = "-----BEGIN CERTIFICATE-----";
     static final String PEM_CERT_END_MARKER = "-----END CERTIFICATE-----";
     static final String LINE_SEPARATOR = System.lineSeparator();


### PR DESCRIPTION
## Description  
Fixing private key issues. Fixed issues:
- Full Bundle contains only 1 reference
- Private Keys are avoided from the Delete bundle
- Private Keys can be loaded from `build.gradle` using `EnvironmentConfig` map.
  For example,
```
  EnvironmentConfig {
        name="privateKeyExample"
        map=[
            "PRIVATE_KEY.tls-client": file("./src/main/gateway/config/private-keys.yml"),
            "PRIVATE_KEY_FILE.tls-client.p12": file("./src/main/gateway/config/privateKeys/tls-client.p12")
        ]
  }
```

## Checklist
- [x] Pull Request Created
- [x] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
