### PR TITLE
Adding support for PrivateKey creation using PrivateKeyImportContext XML

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/BundleFileBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/BundleFileBuilder.java
@@ -12,7 +12,6 @@ import com.ca.apim.gateway.cagatewayconfig.beans.GatewayEntity;
 import com.ca.apim.gateway.cagatewayconfig.beans.Policy;
 import com.ca.apim.gateway.cagatewayconfig.beans.Service;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleArtifacts;
-import com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleDefinedEntities;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleEntityBuilder;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder;
 import com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoader;
@@ -128,10 +127,10 @@ public class BundleFileBuilder {
     }
 
     private void writeBundleArtifacts(final String bundleName, final BundleArtifacts bundleArtifacts, File outputDir) {
-        documentFileUtils.createFile(bundleArtifacts.getBundle(), new File(outputDir,
-                bundleArtifacts.getBundleFileName()).toPath());
-        documentFileUtils.createFile(bundleArtifacts.getDeleteBundle(), new File(outputDir,
-                bundleArtifacts.getDeleteBundleFileName()).toPath());
+        documentFileUtils.createFile(bundleArtifacts.getInstallBundle().getElement(), new File(outputDir,
+                bundleArtifacts.getInstallBundle().getFilename()).toPath());
+        documentFileUtils.createFile(bundleArtifacts.getDeleteBundle().getElement(), new File(outputDir,
+                bundleArtifacts.getDeleteBundle().getFilename()).toPath());
         jsonFileUtils.createBundleMetadataFile(bundleArtifacts.getBundleMetadata(), bundleName, outputDir);
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/PrivateKey.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/PrivateKey.java
@@ -138,9 +138,6 @@ public class PrivateKey extends GatewayEntity {
             setPrivateKeyFile(bundle.getPrivateKeyFiles().get(getAlias()));
         } else if (rootFolder != null && getPrivateKeyFile() == null) {
             loadPrivateKey(this, new File(rootFolder, "config/privateKeys"), false);
-        }
-
-        if (getPrivateKeyFile() != null) {
             bundle.getPrivateKeyFiles().put(getAlias(), getPrivateKeyFile());
         }
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/PrivateKey.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/PrivateKey.java
@@ -136,9 +136,12 @@ public class PrivateKey extends GatewayEntity {
         setKeyStoreType(KeyStoreType.fromName(getKeystore()));
         if (bundle.getPrivateKeyFiles().get(getAlias()) != null) {
             setPrivateKeyFile(bundle.getPrivateKeyFiles().get(getAlias()));
-        }
-        if (rootFolder != null && getPrivateKeyFile() == null) {
+        } else if (rootFolder != null && getPrivateKeyFile() == null) {
             loadPrivateKey(this, new File(rootFolder, "config/privateKeys"), false);
+        }
+
+        if (getPrivateKeyFile() != null) {
+            bundle.getPrivateKeyFiles().put(getAlias(), getPrivateKeyFile());
         }
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleArtifacts.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleArtifacts.java
@@ -8,28 +8,31 @@ package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
 import org.w3c.dom.Element;
 
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
 public class BundleArtifacts {
 
-    private final Element bundle;
-    private final Element deleteBundle;
+    private final Artifact installBundle;
+    private final Artifact deleteBundle;
     private final BundleMetadata bundleMetadata;
-    private final String bundleFileName;
-    private final String deleteBundleFileName;
+
+    // Private Key Import Context XMLs
+    private final Set<Artifact> privateKeyContexts = new HashSet<>();
 
     public BundleArtifacts(Element bundle, Element deleteBundle, BundleMetadata bundleMetadata, String bundleFileName
             , String deleteBundleFileName) {
-        this.bundle = bundle;
-        this.deleteBundle = deleteBundle;
+        this.installBundle = new Artifact(bundle, bundleFileName);
+        this.deleteBundle = new Artifact(deleteBundle, deleteBundleFileName);
         this.bundleMetadata = bundleMetadata;
-        this.bundleFileName = bundleFileName;
-        this.deleteBundleFileName = deleteBundleFileName;
     }
 
-    public Element getBundle() {
-        return bundle;
+    public Artifact getInstallBundle() {
+        return installBundle;
     }
 
-    public Element getDeleteBundle() {
+    public Artifact getDeleteBundle() {
         return deleteBundle;
     }
 
@@ -37,11 +40,42 @@ public class BundleArtifacts {
         return bundleMetadata;
     }
 
-    public String getBundleFileName() {
-        return bundleFileName;
+    public void addPrivateKeyContext(Element contextXml, String filename) {
+        privateKeyContexts.add(new Artifact(contextXml, filename));
     }
 
-    public String getDeleteBundleFileName() {
-        return deleteBundleFileName;
+    public Set<Artifact> getPrivateKeyContexts() {
+        return privateKeyContexts;
+    }
+
+    public static class Artifact {
+        private final Element element;
+        private final String filename;
+
+        public Artifact(Element element, String filename) {
+            this.element = element;
+            this.filename = filename;
+        }
+
+        public Element getElement() {
+            return element;
+        }
+
+        public String getFilename() {
+            return filename;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Artifact artifact = (Artifact) o;
+            return Objects.equals(filename, artifact.filename);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(filename);
+        }
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -23,6 +23,7 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.*;
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.*;
@@ -37,17 +38,20 @@ public class BundleEntityBuilder {
     private final Set<EntityBuilder> entityBuilders;
     private final BundleDocumentBuilder bundleDocumentBuilder;
     private final BundleMetadataBuilder bundleMetadataBuilder;
+    private final PrivateKeyImportContextBuilder privateKeyImportContextBuilder;
     private final EntityTypeRegistry entityTypeRegistry;
 
     @Inject
     BundleEntityBuilder(final Set<EntityBuilder> entityBuilders, final BundleDocumentBuilder bundleDocumentBuilder,
-                        final BundleMetadataBuilder bundleMetadataBuilder, final EntityTypeRegistry entityTypeRegistry) {
+                        final BundleMetadataBuilder bundleMetadataBuilder,
+                        final EntityTypeRegistry entityTypeRegistry, PrivateKeyImportContextBuilder privateKeyImportContextBuilder) {
         // treeset is needed here to sort the builders in the proper order to get a correct bundle build
         // Ordering is necessary for the bundle, for the gateway to load it properly.
         this.entityBuilders = unmodifiableSet(new TreeSet<>(entityBuilders));
         this.bundleDocumentBuilder = bundleDocumentBuilder;
         this.bundleMetadataBuilder = bundleMetadataBuilder;
         this.entityTypeRegistry = entityTypeRegistry;
+        this.privateKeyImportContextBuilder = privateKeyImportContextBuilder;
     }
 
     public Map<String, BundleArtifacts> build(Bundle bundle, BundleType bundleType,
@@ -93,9 +97,10 @@ public class BundleEntityBuilder {
                 // Create DELETE Environment bundle
                 deleteBundleElement = createDeleteEnvBundle(document, entities);
             }
-
-            artifacts.put(bundleNamePrefix, new BundleArtifacts(fullBundle, deleteBundleElement, bundleMetadata,
-                    bundleFileName, deleteBundleFileName));
+            BundleArtifacts bundleArtifacts = new BundleArtifacts(fullBundle, deleteBundleElement, bundleMetadata,
+                    bundleFileName, deleteBundleFileName);
+            addPrivateKeyContexts(bundle, projectInfo, bundleArtifacts, document);
+            artifacts.put(bundleNamePrefix, bundleArtifacts);
         }
         return artifacts;
     }
@@ -147,9 +152,11 @@ public class BundleEntityBuilder {
                                         projectInfo);
                             }
 
-                            annotatedElements.put(annotatedBundle.getBundleName(),
-                                    new BundleArtifacts(bundleElement, deleteBundleElement, bundleMetadata,
-                                            bundleFilename, deleteBundleFilename));
+                            BundleArtifacts artifacts = new BundleArtifacts(bundleElement, deleteBundleElement,
+                                    bundleMetadata, bundleFilename, deleteBundleFilename);
+                            addPrivateKeyContexts(annotatedBundle, projectInfo, artifacts, document);
+                            annotatedElements.put(annotatedBundle.getBundleName(), artifacts);
+
                         })
         );
 
@@ -422,6 +429,26 @@ public class BundleEntityBuilder {
     private String generateBundleFileName(boolean isDeleteBundle, String bundleName) {
         String filenameSuffix = isDeleteBundle ? DELETE_BUNDLE_EXTENSION : INSTALL_BUNDLE_EXTENSION;
         return bundleName + filenameSuffix;
+    }
+
+    public void addPrivateKeyContexts(Bundle bundle, ProjectInfo projectInfo, BundleArtifacts bundleArtifacts,
+                                      Document document) {
+        if (!bundle.getPrivateKeys().isEmpty()) {
+            bundle.getPrivateKeys().forEach((alias, privateKey) -> {
+                if (privateKey.getPrivateKeyFile() == null) {
+                    privateKey.setPrivateKeyFile(bundle.getPrivateKeyFiles().get(privateKey.getAlias()));
+                }
+                if (privateKey.getPrivateKeyFile() != null) {
+                    Element element = privateKeyImportContextBuilder.build(privateKey, document);
+                    String filename = generatePrivateKeyFileName(privateKey, projectInfo);
+                    bundleArtifacts.addPrivateKeyContext(element, filename);
+                }
+            });
+        }
+    }
+
+    private String generatePrivateKeyFileName(PrivateKey privateKey, ProjectInfo projectInfo) {
+        return projectInfo.getName() + "-" + privateKey.getAlias() + "-" + projectInfo.getVersion() + ".privatekey.xml";
     }
 
     @VisibleForTesting

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -451,8 +451,11 @@ public class BundleEntityBuilder {
         StringBuilder filename = new StringBuilder(projectInfo.getName()).append("-").append(privateKey.getAlias());
         if (StringUtils.isNotBlank(projectInfo.getVersion())) {
             filename.append("-").append(projectInfo.getVersion());
+            if (StringUtils.isNotBlank(projectInfo.getConfigName())) {
+                filename.append("-").append(projectInfo.getConfigName());
+            }
         }
-        return filename.append(".privatekey.xml").toString();
+        return filename.append(".privatekey").toString();
     }
 
     @VisibleForTesting

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -448,7 +448,11 @@ public class BundleEntityBuilder {
     }
 
     private String generatePrivateKeyFileName(PrivateKey privateKey, ProjectInfo projectInfo) {
-        return projectInfo.getName() + "-" + privateKey.getAlias() + "-" + projectInfo.getVersion() + ".privatekey.xml";
+        StringBuilder filename = new StringBuilder(projectInfo.getName()).append("-").append(privateKey.getAlias());
+        if (StringUtils.isNotBlank(projectInfo.getVersion())) {
+            filename.append("-").append(projectInfo.getVersion());
+        }
+        return filename.append(".privatekey.xml").toString();
     }
 
     @VisibleForTesting

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PrivateKeyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PrivateKeyEntityBuilder.java
@@ -11,6 +11,7 @@ import com.ca.apim.gateway.cagatewayconfig.beans.PrivateKey;
 import com.ca.apim.gateway.cagatewayconfig.util.gateway.CertificateUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.keystore.KeystoreHelper;
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -25,6 +26,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -40,6 +43,8 @@ import static java.util.stream.Collectors.toList;
 
 @Singleton
 public class PrivateKeyEntityBuilder implements EntityBuilder {
+
+    private static final Logger LOGGER = Logger.getLogger(PolicyEntityBuilder.class.getName());
 
     private static final Integer ORDER = 800;
     private static final String DUMMY_CERTIFICATE = "MIIBfTCCASegAwIBAgIJAPH69zKKw4ixMA0GCSqGSIb3DQEBBQUAMA8xDTALBgNVBAMTBHRlc3QwHhcNMTgxMDEzMDMyODI1WhcNMzgxMDA4MDMyODI1WjAPMQ0wCwYDVQQDEwR0ZXN0MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAIS+Vr8zPOBmSclkUtW/z0UXaMjhg7dix6IUZs+UoSiw/2GXfU2vc3renVAbn3AZaJEqnxgrcX4nldqt0WBIP4sCAwEAAaNmMGQwDgYDVR0PAQH/BAQDAgXgMBIGA1UdJQEB/wQIMAYGBFUdJQAwHQYDVR0OBBYEFN/aeDDEAB6MTxZhMhf/eJKnmaE5MB8GA1UdIwQYMBaAFN/aeDDEAB6MTxZhMhf/eJKnmaE5MA0GCSqGSIb3DQEBBQUAA0EAdolvh7bMX5ZMkM/yntJlBdzS8ukM/ULh8I11wKd6dDltyMuk9rOP0iEk1nsSFuFL0uQ4kIe12KyDwr8ns7VKvQ==";
@@ -96,6 +101,10 @@ public class PrivateKeyEntityBuilder implements EntityBuilder {
 
     private void buildAndAppendCertificateChainElement(PrivateKey privateKey, Element privateKeyElem, Document document) {
         if (privateKey.getPrivateKeyFile() != null) {
+            if (StringUtils.isBlank(privateKey.getKeyPassword())) {
+                LOGGER.log(Level.WARNING, "PrivateKey password not provided, attempting with blank password.");
+                privateKey.setKeyPassword("");
+            }
             final KeyStore keyStore = keystoreHelper.loadKeyStore(privateKey);
             final Certificate[] certificates = keystoreHelper.loadCertificatesForPrivateKey(privateKey, keyStore);
             final Element[] certificatesElements = Stream.of(certificates)

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PrivateKeyImportContextBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PrivateKeyImportContextBuilder.java
@@ -1,0 +1,40 @@
+package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
+
+import com.ca.apim.gateway.cagatewayconfig.beans.PrivateKey;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.inject.Singleton;
+import java.io.IOException;
+
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleDocumentBuilder.GATEWAY_MANAGEMENT;
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BundleDocumentBuilder.L7;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithChildren;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithTextContent;
+
+@Singleton
+public class PrivateKeyImportContextBuilder {
+
+    public Element build(PrivateKey privateKey, Document document) {
+        if (privateKey != null && privateKey.getPrivateKeyFile() != null) {
+            try {
+                String pkcs12Data =
+                        Base64.encodeBase64String(IOUtils.toByteArray(privateKey.getPrivateKeyFile().getWithIO()));
+                Element privateKeyImportContext = createElementWithChildren(
+                        document,
+                        PRIVATE_KEY_IMPORT_CONTEXT,
+                        createElementWithTextContent(document, PRIVATE_KEY_PKCS12_DATA, pkcs12Data),
+                        createElementWithTextContent(document, PRIVATE_KEY_ALIAS, privateKey.getAlias()),
+                        createElementWithTextContent(document, PRIVATE_KEY_PASSWORD, privateKey.getKeyPassword()));
+                privateKeyImportContext.setAttribute(L7, GATEWAY_MANAGEMENT);
+                return privateKeyImportContext;
+            } catch (IOException e) {
+                throw new EntityBuilderException("Couldn't load private key file: " + privateKey.getAlias());
+            }
+        }
+        return null;
+    }
+}

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/PrivateKeyLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/PrivateKeyLoader.java
@@ -36,6 +36,7 @@ public class PrivateKeyLoader implements BundleEntityLoader {
         key.setKeyStoreType(keystore);
         key.setKeystore(keystore.getName());
         key.setAlgorithm((String) properties.get("keyAlgorithm"));
+        key.setKeyPassword("");
 
         bundle.getPrivateKeys().put(alias, key);
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
@@ -31,7 +31,6 @@ import static com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils.collectFiles;
 import static java.util.stream.Collectors.toList;
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.PLUGIN;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @Singleton
 public class EnvironmentBundleCreator {
@@ -78,11 +77,16 @@ public class EnvironmentBundleCreator {
         Map<String, BundleArtifacts> bundleElements = bundleEntityBuilder.build(environmentBundle,
                 EntityBuilder.BundleType.ENVIRONMENT, document, projectInfo, true);
         for (BundleArtifacts bundleArtifacts : bundleElements.values()) {
-            documentFileUtils.createFile(bundleArtifacts.getBundle(), new File(bundleFolderPath,
+            documentFileUtils.createFile(bundleArtifacts.getInstallBundle().getElement(), new File(bundleFolderPath,
                     envInstallBundleFilename).toPath());
-            documentFileUtils.createFile(bundleArtifacts.getDeleteBundle(), new File(bundleFolderPath,
+            documentFileUtils.createFile(bundleArtifacts.getDeleteBundle().getElement(), new File(bundleFolderPath,
                     envInstallBundleFilename.replace(INSTALL_BUNDLE_EXTENSION, DELETE_BUNDLE_EXTENSION)).toPath());
             jsonFileUtils.createBundleMetadataFile(bundleArtifacts.getBundleMetadata(), envInstallBundleFilename.replace(INSTALL_BUNDLE_EXTENSION, ""), new File(bundleFolderPath));
+            if (!bundleArtifacts.getPrivateKeyContexts().isEmpty()) {
+                bundleArtifacts.getPrivateKeyContexts().forEach(privateKey -> {
+                    documentFileUtils.createFile(privateKey.getElement(), new File(bundleFolderPath, privateKey.getFilename()).toPath());
+                });
+            }
         }
         return environmentBundle;
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
@@ -120,7 +120,7 @@ public class FullBundleCreator {
                 public boolean test(Map<String, String> dependentBundleMap) {
                     String version = StringUtils.isNotBlank(projectInfo.getVersion()) ? projectInfo.getMajorVersion() + "." + projectInfo.getMinorVersion() : "";
                     return dependentBundleMap.get("name").equals(projectInfo.getName() + "-" + PREFIX_ENVIRONMENT) && dependentBundleMap.get("groupName").equals(projectInfo.getGroupName()) &&
-                            dependentBundleMap.get("version").equals(version);
+                            (dependentBundleMap.get("version") == null || dependentBundleMap.get("version").equals(version));
                 }
             });
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
@@ -87,9 +87,10 @@ public class FullBundleCreator {
                                  String bundleFolderPath, ProjectInfo projectInfo,
                                  String fullInstallBundleFilename, String environmentConfigurationFolderPath,
                                  boolean detemplatizeDeploymentBundles) {
-        final Pair<Element, Element> elementPair = createFullAndDeleteBundles(bundleEnvironmentValues,
-                dependentBundles, bundleFolderPath, environmentConfigurationFolderPath, detemplatizeDeploymentBundles, projectInfo);
-        final String bundle = documentTools.elementToString(elementPair.getLeft());
+        final BundleArtifacts fullBundleArtifacts = createFullAndDeleteBundles(bundleEnvironmentValues,
+                dependentBundles, bundleFolderPath, environmentConfigurationFolderPath, detemplatizeDeploymentBundles
+                , projectInfo, fullInstallBundleFilename);
+        final String bundle = documentTools.elementToString(fullBundleArtifacts.getInstallBundle().getElement());
         // write the full bundle to a temporary file first
         final File fullBundleFile = new File(System.getProperty(JAVA_IO_TMPDIR), fullInstallBundleFilename);
         try {
@@ -102,7 +103,8 @@ public class FullBundleCreator {
         dependencyBundlesProcessor.process(singletonList(fullBundleFile), bundleFolderPath);
 
         final String fullDeleteBundleFilename = fullInstallBundleFilename.replace(INSTALL_BUNDLE_EXTENSION, DELETE_BUNDLE_EXTENSION);
-        documentFileUtils.createFile(elementPair.getRight(), new File(bundleFolderPath, fullDeleteBundleFilename).toPath());
+        documentFileUtils.createFile(fullBundleArtifacts.getDeleteBundle().getElement(), new File(bundleFolderPath,
+                fullDeleteBundleFilename).toPath());
         // delete the temp file
         boolean deleted = fullBundleFile.delete();
         if (!deleted) {
@@ -134,6 +136,12 @@ public class FullBundleCreator {
             jsonFileUtils.createBundleMetadataFile(bundleMetadata, bundleMetaFileName, new File(bundleFolderPath));
 
         }
+
+        if (!fullBundleArtifacts.getPrivateKeyContexts().isEmpty()) {
+            fullBundleArtifacts.getPrivateKeyContexts().forEach(privateKey -> {
+                documentFileUtils.createFile(privateKey.getElement(), new File(bundleFolderPath, privateKey.getFilename()).toPath());
+            });
+        }
     }
 
     /**
@@ -155,10 +163,11 @@ public class FullBundleCreator {
         }
     }
 
-    private Pair<Element, Element> createFullAndDeleteBundles(final Pair<String, Map<String, String>> bundleEnvironmentValues, final List<File> dependentBundles,
-                                                              String bundleFolderPath,
-                                                              String environmentConfigurationFolderPath,
-                                                              boolean detemplatizeDeploymentBundles, ProjectInfo projectInfo) {
+    private BundleArtifacts createFullAndDeleteBundles(Pair<String, Map<String, String>> bundleEnvironmentValues,
+                                                       List<File> dependentBundles, String bundleFolderPath,
+                                                       String environmentConfigurationFolderPath,
+                                                       boolean detemplatizeDeploymentBundles, ProjectInfo projectInfo,
+                                                       String fullInstallBundleFilename) {
         final Map<String, String> environmentProperties = bundleEnvironmentValues.getRight();
         final List<File> deploymentBundles = collectFiles(bundleFolderPath,
                 bundleEnvironmentValues.getLeft() + INSTALL_BUNDLE_EXTENSION);
@@ -184,15 +193,18 @@ public class FullBundleCreator {
         Element bundleElement = createFullBundleElement(bundleElements, templatizedBundles, document);
         Element deleteBundleElement = createDeleteBundleElement(bundleElements, deploymentDeleteBundle, dependentBundles, document);
 
-
-        return ImmutablePair.of(bundleElement, deleteBundleElement);
+        String fullDeleteBundleFilename = fullInstallBundleFilename.replace(INSTALL_BUNDLE_EXTENSION, DELETE_BUNDLE_EXTENSION);
+        BundleArtifacts fullBundleArtifacts = new BundleArtifacts(bundleElement, deleteBundleElement, null,
+                fullInstallBundleFilename, fullDeleteBundleFilename);
+        bundleEntityBuilder.addPrivateKeyContexts(environmentBundle, projectInfo, fullBundleArtifacts, document);
+        return fullBundleArtifacts;
     }
 
     private Element createFullBundleElement(final Map<String, BundleArtifacts> bundleElements, final List<TemplatizedBundle> templatizedBundles, final Document document) {
         Element bundleElement = null;
         for (Map.Entry<String, BundleArtifacts> entry : bundleElements.entrySet()) {
             // generate the environment bundle
-            bundleElement = entry.getValue().getBundle();
+            bundleElement = entry.getValue().getInstallBundle().getElement();
             Element referencesElement = getSingleChildElement(bundleElement, REFERENCES);
             Element mappingsElement = getSingleChildElement(bundleElement, MAPPINGS);
 
@@ -220,7 +232,7 @@ public class FullBundleCreator {
     private Element createDeleteBundleElement(final Map<String, BundleArtifacts> bundleElements, final List<File> deploymentDeleteBundles, final List<File> dependentBundles, final Document document) {
         Element bundleElement = null;
         for (Map.Entry<String, BundleArtifacts> entry : bundleElements.entrySet()) {
-            bundleElement = entry.getValue().getDeleteBundle();
+            bundleElement = entry.getValue().getDeleteBundle().getElement();
             Element referencesElement = getSingleChildElement(bundleElement, REFERENCES);
             Element mappingsElement = getSingleChildElement(bundleElement, MAPPINGS);
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BundleElementNames.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BundleElementNames.java
@@ -148,6 +148,10 @@ public class BundleElementNames {
     // Private Key
     public static final String PRIVATE_KEY = "l7:PrivateKey";
     public static final String CERTIFICATE_CHAIN = "l7:CertificateChain";
+    public static final String PRIVATE_KEY_IMPORT_CONTEXT = "l7:PrivateKeyImportContext";
+    public static final String PRIVATE_KEY_PKCS12_DATA = "l7:Pkcs12Data";
+    public static final String PRIVATE_KEY_ALIAS = "l7:Alias";
+    public static final String PRIVATE_KEY_PASSWORD= "l7:Password";
 
     // Cassandra Connection
     public static final String CASSANDRA_CONNECTION = "l7:CassandraConnection";

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
@@ -8,7 +8,6 @@ package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
 import com.ca.apim.gateway.cagatewayconfig.ProjectInfo;
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
-import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.AnnotationType;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
@@ -80,7 +79,7 @@ class BundleEntityBuilderTest {
     @Test
     void build() {
         BundleEntityBuilder builder = new BundleEntityBuilder(singleton(new TestEntityBuilder()),
-                new BundleDocumentBuilder(), new BundleMetadataBuilder(ID_GENERATOR), entityTypeRegistry);
+                new BundleDocumentBuilder(), new BundleMetadataBuilder(ID_GENERATOR), entityTypeRegistry, new PrivateKeyImportContextBuilder());
 
         final Map<String, BundleArtifacts> element = builder.build(new Bundle(), DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
@@ -213,14 +212,14 @@ class BundleEntityBuilderTest {
                                                         String expEncassPolicyName, String expEncassPolicyAction, String expEncassName, String expEncassAction,
                                                         String expDepEncassPolicyName, String expDepEncassPolicyAction, String expDepEncassName, String expDepEncassAction) {
         BundleEntityBuilder builder = new BundleEntityBuilder(entityBuilders, new BundleDocumentBuilder(),
-                new BundleMetadataBuilder(ID_GENERATOR), entityTypeRegistry);
+                new BundleMetadataBuilder(ID_GENERATOR), entityTypeRegistry, new PrivateKeyImportContextBuilder());
         Map<String, BundleArtifacts> bundles = builder.build(bundle, DEPLOYMENT,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
         for (Map.Entry<String, BundleArtifacts> bundleEntry : bundles.entrySet()) {
             assertEquals(TEST_ENCASS_ANNOTATION_NAME + "-" + "1.0", bundleEntry.getKey());
-            final Element element = bundleEntry.getValue().getBundle();
+            final Element element = bundleEntry.getValue().getInstallBundle().getElement();
             assertNotNull(element);
             assertEquals(BundleDocumentBuilder.GATEWAY_MANAGEMENT, element.getAttribute(BundleDocumentBuilder.L7));
             assertEquals(BUNDLE, element.getTagName());
@@ -301,7 +300,7 @@ class BundleEntityBuilderTest {
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
-        Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle();
+        Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle().getElement();
         assertNotNull(deleteBundleElement);
 
         // Assert Bundle
@@ -352,7 +351,7 @@ class BundleEntityBuilderTest {
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
-        Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle();
+        Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle().getElement();
         assertNotNull(deleteBundleElement);
 
         // Assert Bundle
@@ -422,7 +421,7 @@ class BundleEntityBuilderTest {
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
-        Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle();
+        Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle().getElement();
         assertNotNull(deleteBundleElement);
 
         // Assert Bundle
@@ -492,7 +491,7 @@ class BundleEntityBuilderTest {
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), projectInfo);
         assertNotNull(bundles);
         assertEquals(1, bundles.size());
-        Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle();
+        Element deleteBundleElement = bundles.get(TEST_ENCASS_ANNOTATION_NAME + "-1.0").getDeleteBundle().getElement();
         assertNotNull(deleteBundleElement);
 
         // Assert Bundle
@@ -563,7 +562,7 @@ class BundleEntityBuilderTest {
         assertEquals(1, bundles.size());
         for (Map.Entry<String, BundleArtifacts> bundleEntry : bundles.entrySet()) {
             assertEquals(TEST_SERVICE_ANNOTATION_NAME + "-" + "1.0", bundleEntry.getKey());
-            final Element element = bundleEntry.getValue().getBundle();
+            final Element element = bundleEntry.getValue().getInstallBundle().getElement();
             assertNotNull(element);
             assertEquals(BundleDocumentBuilder.GATEWAY_MANAGEMENT, element.getAttribute(BundleDocumentBuilder.L7));
             assertEquals(BUNDLE, element.getTagName());

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTestHelper.java
@@ -107,7 +107,7 @@ public class BundleEntityBuilderTestHelper {
         entityBuilders.add(trustedCertEntityBuilder);
 
         return new BundleEntityBuilder(entityBuilders, new BundleDocumentBuilder(),
-                new BundleMetadataBuilder(ID_GENERATOR), entityTypeRegistry);
+                new BundleMetadataBuilder(ID_GENERATOR), entityTypeRegistry, new PrivateKeyImportContextBuilder());
     }
 
     static Encass buildTestEncassWithAnnotation(String encassGuid, String policyPath, boolean isRedeployable) {

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildFullBundleTask.java
@@ -115,11 +115,7 @@ public class BuildFullBundleTask extends DefaultTask {
 
             final Pair<String, Map<String, String>> bundleEnvironmentValues = environmentConfigurationUtils.parseBundleMetadata(metaDataFile, configuredFolder);
             if (null != bundleEnvironmentValues) {
-                String fullInstallBundleFilename = bundleEnvironmentValues.getLeft();
-                if (StringUtils.isNotBlank(projectInfo.getVersion())) {
-                    fullInstallBundleFilename = fullInstallBundleFilename + PREFIX_FULL;
-                }
-                fullInstallBundleFilename = fullInstallBundleFilename + INSTALL_BUNDLE_EXTENSION;
+                String fullInstallBundleFilename = bundleEnvironmentValues.getLeft() + PREFIX_FULL + INSTALL_BUNDLE_EXTENSION;
                 //read environment properties from environmentConfig and merge it with config folder entities
                 if(environmentEntities != null){
                     bundleEnvironmentValues.getRight().putAll(environmentConfigurationUtils.parseEnvironmentValues(environmentEntities));


### PR DESCRIPTION
## Description  
Adding support for PrivateKey creation using PrivateKeyImportContext XML. This creates a `*.privatekey.xml` files if the `.p12` key file is provided in the configuration (through build.gradle or by `privateKeys` folder in the config directory. These XML files are generated only with `build-environment-bundle` and `build-full-bundle` task.

## Checklist
- [x] Pull Request Created
- [ ] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
